### PR TITLE
fix: Revert registry changes

### DIFF
--- a/.github/workflows/deactivate.yml
+++ b/.github/workflows/deactivate.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: SocialGouv/actions/k8s-deactivate@master
+    - uses: SocialGouv/actions/k8s-deactivate@v1
       with:
         kube-config: ${{ secrets.SOCIALGOUV_KUBE_CONFIG_DEV2  }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,7 +6,7 @@ on:
       - v*
 
 concurrency:
-  group: preproduction
+  group: production
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,7 +24,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         imageName: ${{ env.project }}/app
@@ -43,7 +43,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         dockerfile: hasura/Dockerfile
@@ -59,7 +59,7 @@ jobs:
     steps:
 
     - name: Use autodevops manifests generation
-      uses: SocialGouv/actions/k8s-manifests@master
+      uses: SocialGouv/actions/k8s-manifests@v1
       with:
         environment: "preprod"
 
@@ -76,7 +76,7 @@ jobs:
     steps:
   
     - name: Use autodevops deployment
-      uses: SocialGouv/actions/autodevops-deploy@master
+      uses: SocialGouv/actions/autodevops-deploy@v1
       with:
         environment: "preprod"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
     steps:
 
     - name: Use autodevops manifests generation
-      uses: SocialGouv/actions/k8s-manifests@master
+      uses: SocialGouv/actions/k8s-manifests@v1
       with:
         environment: "prod"
 
@@ -108,7 +108,7 @@ jobs:
     steps:
 
     - name: Use autodevops deployment
-      uses: SocialGouv/actions/autodevops-deploy@master
+      uses: SocialGouv/actions/autodevops-deploy@v1
       with:
         environment: "prod"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,11 +24,11 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/harbor-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@master
       with:
+        project: ${{ env.project }}
         imageName: ${{ env.project }}/app
-        harborUsername: ${{ secrets.HARBOR_USERNAME }}
-        harborPassword: ${{ secrets.HARBOR_PASSWORD }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   ##############################################################################
   ## BUILD AND REGISTER HASURA IMAGE
@@ -43,12 +43,13 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/harbor-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@master
       with:
+        project: ${{ env.project }}
         dockerfile: hasura/Dockerfile
+        token: ${{ secrets.GITHUB_TOKEN }}
         imageName: ${{ env.project }}/hasura
-        harborUsername: ${{ secrets.HARBOR_USERNAME }}
-        harborPassword: ${{ secrets.HARBOR_PASSWORD }}
+
   ##############################################################################
   ## GENERATE PREPRODUCTION MANIFESTS
   ##############################################################################
@@ -73,7 +74,7 @@ jobs:
       name: preproduction
       url: https://carnet-de-bord-prepod.dev.fabrique.social.gouv.fr/
     steps:
-
+  
     - name: Use autodevops deployment
       uses: SocialGouv/actions/autodevops-deploy@master
       with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -26,7 +26,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         imageName: ${{ env.project }}/app
@@ -45,7 +45,7 @@ jobs:
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/autodevops-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@v1
       with:
         project: ${{ env.project }}
         dockerfile: hasura/Dockerfile
@@ -61,7 +61,7 @@ jobs:
     steps:
 
     - name: Use autodevops manifests generation
-      uses: SocialGouv/actions/k8s-manifests@master
+      uses: SocialGouv/actions/k8s-manifests@v1
       with:
         environment: "dev"
 
@@ -75,7 +75,7 @@ jobs:
     steps:
 
     - name: Use autodevops deployment
-      uses: SocialGouv/actions/autodevops-deploy@master
+      uses: SocialGouv/actions/autodevops-deploy@v1
       with:
         environment: "dev"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -90,6 +90,6 @@ jobs:
     needs: deploy
     steps:
 
-    - uses: SocialGouv/actions/k8s-restore-db@master
+    - uses: SocialGouv/actions/k8s-restore-db@v1
       with:
         kubeconfig: ${{ secrets.SOCIALGOUV_KUBE_CONFIG_DEV2 }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref }}
+  group: review-${{ github.ref }}
 
 jobs:
 
@@ -69,7 +69,7 @@ jobs:
   ## DEPLOY BACKEND & FRONT-END
   ##############################################################################
   deploy:
-    name: Deploy application
+    name: Deploy review branch
     runs-on: ubuntu-latest
     needs: [register, register-hasura, manifests]
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -25,18 +25,12 @@ jobs:
       run: |
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
-    # - name: Use autodevops build and register
-    #   uses: SocialGouv/actions/autodevops-build-register@master
-    #   with:
-    #     project: ${{ env.project }}
-    #     imageName: ${{ env.project }}/app
-    #     token: ${{ secrets.GITHUB_TOKEN }}
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/harbor-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@master
       with:
+        project: ${{ env.project }}
         imageName: ${{ env.project }}/app
-        harborUsername: ${{ secrets.HARBOR_USERNAME }}
-        harborPassword: ${{ secrets.HARBOR_PASSWORD }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   ##############################################################################
   ## BUILD AND REGISTER HASURA IMAGE
@@ -50,20 +44,13 @@ jobs:
       run: |
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
-    # - name: Use autodevops build and register
-    #   uses: SocialGouv/actions/autodevops-build-register@master
-    #   with:
-    #     project: ${{ env.project }}
-    #     dockerfile: hasura/Dockerfile
-    #     token: ${{ secrets.GITHUB_TOKEN }}
-    #     imageName: ${{ env.project }}/hasura
     - name: Use autodevops build and register
-      uses: SocialGouv/actions/harbor-build-register@master
+      uses: SocialGouv/actions/autodevops-build-register@master
       with:
+        project: ${{ env.project }}
         dockerfile: hasura/Dockerfile
+        token: ${{ secrets.GITHUB_TOKEN }}
         imageName: ${{ env.project }}/hasura
-        harborUsername: ${{ secrets.HARBOR_USERNAME }}
-        harborPassword: ${{ secrets.HARBOR_PASSWORD }}
 
   ##############################################################################
   ## GENERATE KUBERNETES MANIFESTS

--- a/.k8s/components/app.ts
+++ b/.k8s/components/app.ts
@@ -40,7 +40,7 @@ export const getManifests = async () => {
 			containerPort: 3000
 		},
 		deployment: {
-			image: `harbor.fabrique.social.gouv.fr/carnet-de-bord/app:sha-${ciEnv.sha}`,
+			image: `ghcr.io/socialgouv/carnet-de-bord/app:sha-${ciEnv.sha}`,
 			container: {
 				resources: {
 					requests: {

--- a/.k8s/components/hasura.ts
+++ b/.k8s/components/hasura.ts
@@ -12,7 +12,7 @@ export async function getManifests() {
 	const config = {
 		config: { ingress: hasura === 'exposed' },
 		deployment: {
-			image: `harbor.fabrique.social.gouv.fr/carnet-de-bord/hasura:sha-${ciEnv.sha}`
+			image: `ghcr.io/socialgouv/carnet-de-bord/hasura:sha-${ciEnv.sha}`
 		},
 		env
 	};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.36.2-alpha.2](https://github.com/SocialGouv/carnet-de-bord/compare/v1.36.2-alpha.1...v1.36.2-alpha.2) (2021-09-23)
+
+
+### Bug Fixes
+
+* Minor fixes ([8e9863d](https://github.com/SocialGouv/carnet-de-bord/commit/8e9863d3dcc13f844a1806a18523a83d21ad44db))
+* Use socialgouv/actions@v1 ([beeb492](https://github.com/SocialGouv/carnet-de-bord/commit/beeb4925cf1d286a45191918806c0aa9f480b399))
+
 ## [1.36.2-alpha.1](https://github.com/SocialGouv/carnet-de-bord/compare/v1.36.1...v1.36.2-alpha.1) (2021-09-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.36.2-alpha.1](https://github.com/SocialGouv/carnet-de-bord/compare/v1.36.1...v1.36.2-alpha.1) (2021-09-23)
+
+
+### Bug Fixes
+
+* Revert registry changes on preprod and prod ([119fd5c](https://github.com/SocialGouv/carnet-de-bord/commit/119fd5c422fc2c7bb7c2cd36c2a7df9cf5771d31))
+* Revert registry changes on review branches ([a24a499](https://github.com/SocialGouv/carnet-de-bord/commit/a24a4992a6b89f4e321b1d5f2a38abdc7a1a2c78))
+
+
+### Reverts
+
+* Revert "fix: Use Harbor as registry" ([799796e](https://github.com/SocialGouv/carnet-de-bord/commit/799796e3a5135504448a28f9298ee40e9dfe6dfc))
+* Revert "Change image base url" ([5b96473](https://github.com/SocialGouv/carnet-de-bord/commit/5b964737bb8fe1f243188b6da635684deaf72c08))
+* Revert "fix(ci): use harbor in production workflow (#244)" ([e5c3052](https://github.com/SocialGouv/carnet-de-bord/commit/e5c3052571c97eb904db37e4cf548cb8c5508778)), closes [#244](https://github.com/SocialGouv/carnet-de-bord/issues/244)
+
 ## [1.36.1](https://github.com/SocialGouv/carnet-de-bord/compare/v1.36.0...v1.36.1) (2021-09-23)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "carnet-de-bord",
-	"version": "1.36.1",
+	"version": "1.36.2-alpha.1",
 	"engines": {
 		"node": "16",
 		"npm": "7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "carnet-de-bord",
-	"version": "1.36.2-alpha.1",
+	"version": "1.36.2-alpha.2",
 	"engines": {
 		"node": "16",
 		"npm": "7"


### PR DESCRIPTION
This reverts commit d0bc565042c3f61d6bb5bce5f2489ee0eee229e2.

Since we found the reason why the `Github registry` was rejecting our packages updates (aka: The 403 problem), we could leave `Harbor` and move back to `ghcr.io`.