### PR TITLE
feat: add client tracking

### DIFF
--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -172,6 +172,8 @@ data:
   SMTP_PORT: '2500'
   SMTP_FROM: contact.carnet-de-bord@fabrique.social.gouv.fr
   API_PARTICULIER_URL: https://particulier.api.gouv.fr/api
+  VITE_MATOMO_URL: https://matomo.fabrique.social.gouv.fr/
+  VITE_MATOMO_SITE_ID: '51'
 ---
 apiVersion: v1
 kind: Service

--- a/.k8s/environments/prod/app.configmap.yaml
+++ b/.k8s/environments/prod/app.configmap.yaml
@@ -7,3 +7,5 @@ data:
   SMTP_PORT: '2500'
   SMTP_FROM: contact.carnet-de-bord@fabrique.social.gouv.fr
   API_PARTICULIER_URL: https://particulier.api.gouv.fr/api
+  VITE_MATOMO_URL: https://matomo.fabrique.social.gouv.fr/
+  VITE_MATOMO_SITE_ID: '51'

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,5 +3,7 @@
 interface ImportMeta {
 	env: {
 		VITE_GRAPHQL_API_URL: string;
+		VITE_MATOMO_URL: string;
+		VITE_MATOMO_SITE_ID: string;
 	};
 }

--- a/src/lib/config/variables/public.ts
+++ b/src/lib/config/variables/public.ts
@@ -15,3 +15,11 @@ function find(name: string): string {
 	const processEnvVar = process?.env[name];
 	return processEnvVar || importEnvVar;
 }
+
+export function getMatomoUrl(): string | null {
+	return (import.meta.env['VITE_MATOMO_URL'] as string) ?? null;
+}
+
+export function getMatomoSIteId(): string | null {
+	return (import.meta.env['VITE_MATOMO_SITE_ID'] as string) ?? null;
+}

--- a/src/lib/tracking/matomo.ts
+++ b/src/lib/tracking/matomo.ts
@@ -1,0 +1,59 @@
+type Matomo = {
+	initialized: boolean;
+};
+
+declare global {
+	interface Window {
+		Matomo?: Matomo;
+		_paq: string[][];
+	}
+}
+
+export function load(url: string, siteId: string): void {
+	if (document.getElementById('matomo-script')) {
+		// early return; we don't need 2 scripts
+		return;
+	}
+	window._paq = window._paq || [];
+	window._paq.push(['trackPageView']);
+	window._paq.push(['enableLinkTracking']);
+	const scriptElement = document.createElement('script');
+	const firstScriptElement = document.getElementsByTagName('script')[0];
+	scriptElement.type = 'text/javascript';
+	scriptElement.async = true;
+	scriptElement.id = 'matomo-script';
+	scriptElement.src = `${url}/matomo.js`;
+	scriptElement.onload = () => {
+		window._paq.push(['setTrackerUrl', `${url}/matomo.php`]);
+		window._paq.push(['setSiteId', siteId]);
+		onMatomoReady();
+	};
+
+	if (firstScriptElement.parentNode) {
+		firstScriptElement.parentNode.insertBefore(scriptElement, firstScriptElement);
+	}
+}
+
+function onMatomoReady() {
+	console.log(window.Matomo);
+}
+
+export function trackPageView(): void {
+	_push(['trackPageView']);
+}
+
+export function trackEvent(category: string, action: string, name?: string, value?: string): void {
+	const eventParams = ['trackEvent', category, action, name, value].filter(Boolean);
+	_push([...eventParams]);
+}
+
+/**
+ * push allow access directly to push
+ *
+ */
+export function _push(params: string[]): void {
+	if (!window._paq) {
+		window._paq = [];
+	}
+	window._paq.push(params);
+}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -9,6 +9,7 @@
 	import { offCanvas } from '$lib/stores';
 
 	import { onMount } from 'svelte';
+	import * as Matomo from '$lib/tracking/matomo';
 
 	export async function load({ context, page, session }: LoadInput): Promise<LoadOutput> {
 		const redirect = redirectUrl(page, session);
@@ -32,9 +33,17 @@
 </script>
 
 <script lang="ts">
+	import { page } from '$app/stores';
+	import { browser } from '$app/env';
+	import { getMatomoSIteId, getMatomoUrl } from '$lib/config/variables/public';
+
 	export let client: Client;
-	let scrollbarWidth = '0';
 	setClient(client);
+
+	const MATOMO_URL = getMatomoUrl();
+	const MATOMO_SITE_ID = getMatomoSIteId();
+
+	let scrollbarWidth = '0';
 
 	onMount(() => {
 		const { body } = document;
@@ -51,7 +60,13 @@
 		// Remove element
 		body.removeChild(scrollDiv);
 		body.style.setProperty('--scrollbarWidth', scrollbarWidth);
+
+		Matomo.load(MATOMO_URL, MATOMO_SITE_ID);
 	});
+
+	$: {
+		$page.path, browser && Matomo.trackPageView();
+	}
 </script>
 
 <svelte:head>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,15 +1,22 @@
-<script lang="ts">
+<script context="module" type="ts">
 	import { homeForRole } from '$lib/routes';
-	import { session } from '$app/stores';
-	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
 
-	onMount(async () => {
-		const user = $session.user;
-		if (user) {
-			const { role } = user;
-			const home = homeForRole(role);
-			goto(home);
+	export async function load({ session }) {
+		const { user } = session;
+
+		if (!user) {
+			return {
+				status: 302,
+				redirect: '/login',
+			};
 		}
-	});
+		const { role } = user;
+
+		const home = homeForRole(role);
+
+		return {
+			status: 302,
+			redirect: home,
+		};
+	}
 </script>

--- a/src/routes/pro/index.svelte
+++ b/src/routes/pro/index.svelte
@@ -1,9 +1,21 @@
-<script lang="ts">
+<script lang="ts" context="module">
 	import { homeForRole } from '$lib/routes';
-	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
 
-	onMount(() => {
-		goto(homeForRole('pro'));
-	});
+	export async function load({ session }) {
+		const { user } = session;
+
+		if (!user) {
+			return {
+				status: 302,
+				redirect: '/login',
+			};
+		}
+		const { role } = user;
+
+		const home = homeForRole(role);
+		return {
+			status: 302,
+			redirect: home,
+		};
+	}
 </script>


### PR DESCRIPTION
- Ajout du tracker matomo
- modification des redirects pour qu'ils soient fait coté serveur (pour éviter d'avoir la page avant redirection qui remonte dans matomo)

il va falloir tracker a la main les ouvertures de panneaux et les différent formulaire aussi


il faudrait aussi renseigner le la balise title dans nos page
```svelte
<svelte:head>
  <title>titre de la page - carnet de bord</title>
</svelte:head>
```

closes  #306