### PR TITLE
fix: verify token on handle / security

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,17 +1,25 @@
+import { getJwtKey } from '$lib/config/variables/private';
 import { getGraphqlAPI } from '$lib/config/variables/public';
 import type { GetSession, Handle } from '@sveltejs/kit';
 import cookie from 'cookie';
 import { config } from 'dotenv';
-import jwtDecode from 'jwt-decode';
+// jsonwebtoken is cjs module and has no  verify named export
+import jwt from 'jsonwebtoken';
 
 config();
 
 export const handle: Handle = async ({ request, resolve }) => {
 	const cookies = cookie.parse(request.headers.cookie || '');
 	if (cookies.jwt) {
-		const user = jwtDecode(cookies.jwt);
-		request.locals.user = user;
-		request.locals.token = cookies.jwt;
+		try {
+			const { key, type } = getJwtKey();
+			const user = jwt.verify(cookies.jwt, key, { algorithms: [type] });
+			request.locals.user = user;
+			request.locals.token = cookies.jwt;
+		} catch (error) {
+			request.locals.user = null;
+			request.locals.token = null;
+		}
 	} else {
 		request.locals.user = null;
 		request.locals.token = null;

--- a/src/lib/config/variables/private.ts
+++ b/src/lib/config/variables/private.ts
@@ -1,4 +1,5 @@
 import { config } from 'dotenv';
+import type { Algorithm } from 'jsonwebtoken';
 
 config();
 
@@ -41,7 +42,7 @@ export function getSmtpConfig(): {
 
 export function getJwtKey(): {
 	key: string;
-	type: string;
+	type: Algorithm;
 } {
 	const hasuraJwtSecret = process.env['HASURA_GRAPHQL_JWT_SECRET'];
 	let jwtSecret;

--- a/src/lib/ui/utils/LoaderIndicator.svelte
+++ b/src/lib/ui/utils/LoaderIndicator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { OperationStore } from '@urql/svelte';
+	import { LayerCDB } from '..';
 
 	export let result: OperationStore;
 </script>
@@ -7,10 +8,12 @@
 {#if $result.fetching}
 	<div class="flex items-center justify-center">
 		<p>Chargement en cours...</p>
+		<LayerCDB />
 	</div>
 {:else if $result.error}
 	<div class="flex items-center justify-center">
 		<p>Une erreur s'est produite. Si le problème persiste, veuillez nous contacter.</p>
+		<LayerCDB />
 	</div>
 {:else}
 	<slot />

--- a/src/lib/ui/views/Disconnect.svelte
+++ b/src/lib/ui/views/Disconnect.svelte
@@ -4,7 +4,6 @@
 	import { openComponent } from '$lib/stores';
 	import { post } from '$lib/utils/post';
 	import Button from '$lib/ui/base/Button.svelte';
-	import * as Matomo from '$lib/tracking/matomo';
 
 	function closeLayer() {
 		openComponent.close();
@@ -12,7 +11,6 @@
 
 	async function logout() {
 		await post(`/auth/logout`, {});
-		Matomo.disconnectUser();
 		$session.user = null;
 		closeLayer();
 		goto('/');

--- a/src/lib/utils/security.ts
+++ b/src/lib/utils/security.ts
@@ -1,6 +1,8 @@
 import cookie from 'cookie';
-import jwtDecode from 'jwt-decode';
+// jsonwebtoken is cjs module and has no  verify named export
+import jwt from 'jsonwebtoken';
 import type { RequestHandler } from '@sveltejs/kit';
+import { getJwtKey } from '$lib/config/variables/private';
 
 export const authorizeOnly =
 	(roles: string[]) =>
@@ -9,7 +11,10 @@ export const authorizeOnly =
 		if (!cookies.jwt) {
 			throw Error('Unauthorized access');
 		}
-		const user = jwtDecode(cookies.jwt) as { role?: string } | null;
+		const { key, type } = getJwtKey();
+		const user = jwt.verify(cookies.jwt, key, { algorithms: [type] }) as {
+			role?: string;
+		} | null;
 		if (!user || !user.role || !roles.includes(user.role)) {
 			throw Error('Unauthorized access');
 		}

--- a/src/routes/auth/jwt/[uuid].svelte
+++ b/src/routes/auth/jwt/[uuid].svelte
@@ -34,7 +34,7 @@
 				accessKey,
 			}),
 		});
-		if (response.status === 200) {
+		if (response.ok) {
 			const { jwt } = await response.json();
 			const user = jwtDecode(jwt);
 			$session.user = user;


### PR DESCRIPTION
Use verify method to ensure a token is valid (decode is only there to read token props)
fix logout bug
fix #373 