### PR TITLE
fix: update permision to filter pro using deploymentId

### DIFF
--- a/hasura/metadata/databases/carnet_de_bord/tables/public_professional.yaml
+++ b/hasura/metadata/databases/carnet_de_bord/tables/public_professional.yaml
@@ -77,7 +77,10 @@ select_permissions:
     - mobile_number
     - position
     - structure_id
-    filter: {}
+    filter:
+      structure:
+        deployment_id:
+          _eq: X-Hasura-Deployment-Id
   role: professional
 update_permissions:
 - permission:


### PR DESCRIPTION
fix #383 