### PR TITLE
ci: fix manifest name for e2e on preproduction pipeline

### DIFF
--- a/.github/workflows/preproduction.yml
+++ b/.github/workflows/preproduction.yml
@@ -108,7 +108,7 @@ jobs:
         uses: mikefarah/yq@v4.13.4
         id: url
         with:
-          cmd: echo $(cat manifests-dev.yml | yq eval-all '.spec.rules[]?.host' - | head -n 1)
+          cmd: echo $(cat manifests-preprod.yml | yq eval-all '.spec.rules[]?.host' - | head -n 1)
       - name: Run test e2e
         run: |
           CODECEPT_BASEURL=https://${{ steps.url.outputs.result }} yarn --cwd e2e test


### PR DESCRIPTION
preprod pipeline failed due to misconfiguration of e2e  (missing artifact)
cf  https://github.com/SocialGouv/carnet-de-bord/actions/runs/1559842054