### PR TITLE
fix(secu): use non-privilegied docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ RUN yarn build
 
 EXPOSE 3000
 
+USER 1000
+
 CMD [ "node", "build" ]


### PR DESCRIPTION
Ceci permet de forcer un user non privilégié pour faire tourner le container docker

A quoi correspond le `node build` dans l'entrypoint à la fin Dockerfile ?

Ce serait aussi bien de supprimer les dépendances de dev de l'image finale, par ex avec un `yarn --production` après le build