### PR TITLE
feat: add created_at to notebook member detail

### DIFF
--- a/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -6957,6 +6957,7 @@ export type GetNotebookQuery = {
 					memberType: string;
 					lastModifiedAt?: string | null | undefined;
 					lastVisitedAt?: string | null | undefined;
+					createdAt: string;
 					professional: {
 						__typename?: 'professional';
 						id: string;
@@ -13591,6 +13592,7 @@ export const GetNotebookDocument = {
 											{ kind: 'Field', name: { kind: 'Name', value: 'memberType' } },
 											{ kind: 'Field', name: { kind: 'Name', value: 'lastModifiedAt' } },
 											{ kind: 'Field', name: { kind: 'Name', value: 'lastVisitedAt' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
 											{
 												kind: 'Field',
 												name: { kind: 'Name', value: 'professional' },

--- a/src/lib/ui/ProNotebookMember/ProNotebookMemberView.svelte
+++ b/src/lib/ui/ProNotebookMember/ProNotebookMemberView.svelte
@@ -1,7 +1,10 @@
 <script lang="ts" context="module">
 	import type { Pro } from './ProWithStructureView.svelte';
+
+	import { formatDateLocale } from '$lib/utils/date';
 	export type Member = {
 		professional: Pro;
+		createdAt: string;
 	};
 </script>
 
@@ -12,10 +15,12 @@
 
 	export let member: Member;
 	$: professional = member?.professional;
+	$: createdAt = member?.createdAt;
 </script>
 
 <div class="flex flex-col gap-6">
 	<h1>Membre du groupe de suivi</h1>
+	<p>Membre depuis le {formatDateLocale(createdAt)}</p>
 	<ProWithStructureView {professional} />
 	<div class="mt-6">
 		<Button

--- a/src/routes/pro/carnet/_getNotebook.gql
+++ b/src/routes/pro/carnet/_getNotebook.gql
@@ -42,6 +42,7 @@ query GetNotebook($id: uuid!, $eventsStart: date, $eventsEnd: date) {
 			memberType
 			lastModifiedAt
 			lastVisitedAt
+			createdAt
 			professional {
 				id
 				lastname


### PR DESCRIPTION
Affichage de la date d'ajout d'un pro dans le détail du groupe de suivi.

Issue https://github.com/SocialGouv/carnet-de-bord/issues/596

![Screenshot_2022-02-14_12-24-03](https://user-images.githubusercontent.com/154904/153855552-0a8457c9-7ea6-44ba-a962-3d2711bfd846.png)
