### PR TITLE
fix: revert uniqueness on beneficiary_structure to exclude status

### DIFF
--- a/hasura/migrations/carnet_de_bord/1645787372124_benef_struct_uniqueness/down.sql
+++ b/hasura/migrations/carnet_de_bord/1645787372124_benef_struct_uniqueness/down.sql
@@ -1,0 +1,3 @@
+
+alter table "public"."beneficiary_structure" drop constraint "beneficiary_structure_structure_id_beneficiary_id_key";
+alter table "public"."beneficiary_structure" add constraint "beneficiary_structure_structure_id_status_beneficiary_id_key" unique ("structure_id", "status", "beneficiary_id");

--- a/hasura/migrations/carnet_de_bord/1645787372124_benef_struct_uniqueness/up.sql
+++ b/hasura/migrations/carnet_de_bord/1645787372124_benef_struct_uniqueness/up.sql
@@ -1,0 +1,3 @@
+
+alter table "public"."beneficiary_structure" drop constraint "beneficiary_structure_beneficiary_id_structure_id_status_key";
+alter table "public"."beneficiary_structure" add constraint "beneficiary_structure_structure_id_beneficiary_id_key" unique ("structure_id", "beneficiary_id");


### PR DESCRIPTION
Fixes #660 