### PR TITLE
fix: run prettier only on JS files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
     hooks:
       - id: prettier
         args: [--config, .prettierrc, --write] # edit files in-place
+        files: \.(svelte|js|ts)$
         additional_dependencies:
           - prettier
           - prettier-plugin-svelte


### PR DESCRIPTION
Prettier essaie de changer le changelog.md, cette PR permet de le lancer que sur les fichiers JS/svelte/TS.


remplace #787 