### PR TITLE
fix: fix old video link

### DIFF
--- a/src/routes/auth/__layout.svelte
+++ b/src/routes/auth/__layout.svelte
@@ -16,7 +16,7 @@
 			 * Video with voiceover
 			 */
 			{
-				url: 'https://nextcloud.fabrique.social.gouv.fr/s/ZymqnnGR8LcALFf/download/intro-cdb-voiceover.mp4',
+				url: 'https://nextcloud.fabrique.social.gouv.fr/s/KjFZxq4CFE76fyD/download/intro-cdb-voiceover.mp4',
 				type: 'video/mp4',
 			},
 


### PR DESCRIPTION
j'ai regénéré un lien de partage depuis nextloud; le précédent n'avait plus l'air d'exister.

closes #819 