### PR TITLE
feat: split fetch and parse

### DIFF
--- a/.kube-workflow/preprod/templates/cronjob.yaml
+++ b/.kube-workflow/preprod/templates/cronjob.yaml
@@ -1,1 +1,0 @@
-../../prod/templates/cronjob.yaml

--- a/.kube-workflow/preprod/templates/pe-fetch.cronjob.yaml
+++ b/.kube-workflow/preprod/templates/pe-fetch.cronjob.yaml
@@ -1,0 +1,1 @@
+../../prod/templates/pe-fetch.cronjob.yaml

--- a/.kube-workflow/preprod/templates/pe-parse.cronjob.yaml
+++ b/.kube-workflow/preprod/templates/pe-parse.cronjob.yaml
@@ -1,0 +1,1 @@
+../../prod/templates/pe-parse.cronjob.yaml

--- a/.kube-workflow/prod/templates/pe-fetch.cronjob.yaml
+++ b/.kube-workflow/prod/templates/pe-fetch.cronjob.yaml
@@ -2,20 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   labels:
-    component: pe-cronjob
+    component: pe-fetch-cronjob
     application: carnet-de-bord
-  name: pe-cronjob
+  name: pe-fetch-cronjob
 spec:
-  schedule: 0 23 * * 4
+  schedule: 0 0 * * 5
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
         metadata:
           labels:
-            component: pe-cronjob
+            component: pe-fetch-cronjob
             application: carnet-de-bord
-          name: pe-cronjob
+          name: pe-fetch-cronjob
         spec:
           restartPolicy: OnFailure
           volumes:
@@ -27,7 +27,7 @@ spec:
               image: ghcr.io/socialgouv/carnet-de-bord/backend:{{ .Values.global.imageTag }}
               command:
                 - bash
-                - 'scripts/pe-parse.sh'
+                - 'scripts/pe-fetch.sh'
               envFrom:
                 - secretRef:
                     name: backend-sealed-secret

--- a/.kube-workflow/prod/templates/pe-parse.cronjob.yaml
+++ b/.kube-workflow/prod/templates/pe-parse.cronjob.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    component: pe-parse-cronjob
+    application: carnet-de-bord
+  name: pe-parse-cronjob
+spec:
+  schedule: 0 23 * * 4
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            component: pe-parse-cronjob
+            application: carnet-de-bord
+          name: pe-parse-cronjob
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: pefiles
+              persistentVolumeClaim:
+                claimName: pefiles
+          containers:
+            - name: cronjob-container
+              image: ghcr.io/socialgouv/carnet-de-bord/backend:{{ .Values.global.imageTag }}
+              command:
+                - python
+                - 'scripts/parse_csv_pe.py'
+                - 'principal-file'
+                - '/mnt/pefiles/principal.csv'
+              envFrom:
+                - secretRef:
+                    name: backend-sealed-secret
+                - secretRef:
+                    name: cronjob-storage
+                - configMapRef:
+                    name: backend-configmap
+              volumeMounts:
+                - mountPath: /mnt/pefiles
+                  name: pefiles

--- a/backend/scripts/pe-fetch.sh
+++ b/backend/scripts/pe-fetch.sh
@@ -24,5 +24,3 @@ echo "fichier actions: $(wc -l actions.csv) lignes"
 
 cp principal.csv /mnt/pefiles
 cp actions.csv /mnt/pefiles
-
-python scripts/parse_csv_pe.py principal-file /mnt/pefiles/principal.csv


### PR DESCRIPTION
split parse and fetch action for pe script 
- rename `pe-parse.sh` into `pe-fetch.sh`
- remove python cli from pe-fetch script
- add a new cronjob pe-parse that launch python script