### PR TITLE
refactor: add some spacing before Professionals table

### DIFF
--- a/src/routes/manager/professionnels/index.svelte
+++ b/src/routes/manager/professionnels/index.svelte
@@ -118,7 +118,7 @@
 </svelte:head>
 
 <LoaderIndicator {result}>
-	<div class={`w-full fr-table fr-table--layout-fixed`}>
+	<div class={`w-full fr-table fr-table--layout-fixed fr-mt-6w`}>
 		<table>
 			<thead>
 				<tr>


### PR DESCRIPTION
For pleasure of the eye.
Before: 
![before](https://user-images.githubusercontent.com/11717603/187709122-48bad9f0-8b37-4fce-8492-f78a26c53b1e.png)
After: 
![after](https://user-images.githubusercontent.com/11717603/187709110-aa4992d1-9e15-49ca-9ce9-559d9d4d31f2.png)
