### PR TITLE
fix: display that RSA is not defined when RSA rights are null

### DIFF
--- a/src/lib/constants/keys.ts
+++ b/src/lib/constants/keys.ts
@@ -37,6 +37,7 @@ export const rsaRightKeys = buildKeys({
 	rsa_droit_ouvert_et_suspendu: 'Droit ouvert et suspendu',
 	rsa_droit_ouvert_versable: 'Droit ouvert et versable',
 	rsa_droit_ouvert_versement_suspendu: 'Droit ouvert mais versement suspendu',
+	null: 'Droit non renseigné',
 });
 
 export const geographicalAreaKeys = buildKeys({


### PR DESCRIPTION
## :unicorn: Problème
Il arrive que les droits RSA ne soient pas renseignés. 
Cela a pour conséquence d'afficher `RSA - undefined` dans le carnet de bord.

cf. #1015 

## :robot: Solution
Lorsque les droits ne sont pas renseignés, la colonne en base de données est renseignée à `NULL`.  
Pour afficher `RSA - Droit non renseigné`, on ajoute une valeur à la map `rsaRightKeys` (dans le fichier [src/lib/constants/keys.ts]())

## :rainbow: Remarques
RAS

## :100: Pour tester
# Test n°1
1- Se connecter à carnet de bord
2- Dans la liste des bénéficiaires, choisir un bénéficiaire dont la donnée "droit RSA" est vide qui n'est pas assigné au compte utilisé  <img width="117" alt="non assigné" src="https://user-images.githubusercontent.com/2989532/188704136-5a8992f2-16ee-489b-9437-381bcbca8bf5.png">

# Comportement attendu
Dans la section "Situation socioprofessionnelle", vérifier que s'affiche `RSA - Droit non renseigné`.

# Test n°2
1- Se connecter à carnet de bord
2- Dans la liste des bénéficiaires, choisir un bénéficiaire choisir un bénéficiaire dont la donnée "droit RSA" est vide et qui est assigné au compte utilisé.

# Comportement attendu
Dans la section "Situation socioprofessionnelle", vérifier que s'affiche `RSA - Droit non renseigné`.

<img width="1226" alt="RSA - Droits non renseignés" src="https://user-images.githubusercontent.com/2989532/188705096-8658261c-4258-4f5b-bf49-491e529cb147.png">
