### PR TITLE
fix: allow add existing admin to structure

### DIFF
--- a/backend/api/db/crud/admin_structure.py
+++ b/backend/api/db/crud/admin_structure.py
@@ -1,10 +1,17 @@
 import logging
+from typing import List, Tuple
 from uuid import UUID
 
 from asyncpg import Record
 from asyncpg.connection import Connection
 
-from api.db.models.admin_structure import AdminStructure
+from api.db.crud.account import (
+    create_username,
+    get_accounts_with_query,
+    insert_admin_structure_account,
+)
+from api.db.models.account import AccountDB
+from api.db.models.admin_structure import AdminStructure, AdminStructureStructureInput
 
 
 def parse_admin_structure_from_record(record: Record) -> AdminStructure:
@@ -46,7 +53,6 @@ async def insert_admin_structure_structure(
         admin_structure_id,
         structure_id,
     )
-
     if record:
         return record["id"]
     else:
@@ -71,3 +77,51 @@ async def get_admin_structure_with_query(
 
     if record:
         return parse_admin_structure_from_record(record)
+
+
+async def create_admin_structure_with_account(
+    connection: Connection, data: AdminStructureStructureInput
+) -> Tuple[AccountDB, AdminStructure]:
+    """
+    Creation d'un profil admin_structure et du compte associé
+    """
+
+    admin_structure: AdminStructure | None = await insert_admin_structure(
+        connection=connection, data=data.admin
+    )
+
+    if admin_structure is None:
+        raise InsertFailError("insert admin_structure failed")
+
+    email_username: str = data.admin.email.split("@")[0].lower()
+
+    accounts: List[AccountDB] = await get_accounts_with_query(
+        connection,
+        """
+        WHERE account.username like $1
+        """,
+        email_username + "%",
+    )
+
+    username: str = create_username(
+        email_username, [account.username for account in accounts]
+    )
+
+    account: AccountDB | None = await insert_admin_structure_account(
+        connection=connection,
+        admin_structure_id=admin_structure.id,
+        confirmed=True,
+        username=username,
+    )
+
+    if not account:
+        logging.error("Insert account failed")
+        raise InsertFailError("insert account failed")
+
+    return account, admin_structure
+
+
+class InsertFailError(Exception):
+    """
+    utility class when insert goes wrong
+    """

--- a/backend/api/db/crud/admin_structure.py
+++ b/backend/api/db/crud/admin_structure.py
@@ -53,3 +53,21 @@ async def insert_admin_structure_structure(
         logging.error(
             f"insert_admin_structure_structure fail {admin_structure_id} {structure_id}"
         )
+
+
+async def get_admin_structure_with_query(
+    connection: Connection, query: str, *args
+) -> AdminStructure | None:
+
+    record: Record = await connection.fetchrow(
+        """
+        SELECT admin_structure.* FROM public.admin_structure
+        {query}
+        """.format(
+            query=query
+        ),
+        *args,
+    )
+
+    if record:
+        return parse_admin_structure_from_record(record)

--- a/backend/api/v1/routers/admin_structures.py
+++ b/backend/api/v1/routers/admin_structures.py
@@ -1,22 +1,20 @@
 import logging
-import uuid
-from http.client import HTTPException
+from typing import Tuple
+from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from asyncpg.exceptions import UniqueViolationError
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from api.core.emails import generic_account_creation_email
 from api.core.init import connection
 from api.core.settings import settings
-from api.db.crud.account import (
-    create_username,
-    get_accounts_with_query,
-    insert_admin_structure_account,
-)
 from api.db.crud.admin_structure import (
+    InsertFailError,
+    create_admin_structure_with_account,
     get_admin_structure_with_query,
-    insert_admin_structure,
     insert_admin_structure_structure,
 )
+from api.db.models.account import AccountDB
 from api.db.models.admin_structure import AdminStructure, AdminStructureStructureInput
 from api.db.models.role import RoleEnum
 from api.sendmail import send_mail
@@ -36,7 +34,7 @@ async def create_admin_structure(
     db=Depends(connection),
 ):
     async with db.transaction():
-        admin_structure = await get_admin_structure_with_query(
+        admin_structure: AdminStructure | None = await get_admin_structure_with_query(
             db,
             """
             , public.account
@@ -45,68 +43,71 @@ async def create_admin_structure(
             """,
             data.admin.email,
         )
-
         if not admin_structure:
-            admin_structure = await insert_admin_structure(
-                connection=db, data=data.admin
-            )
+            try:
+                account_admin_tuple: Tuple[
+                    AccountDB, AdminStructure
+                ] = await create_admin_structure_with_account(db, data)
+                account, admin_structure = account_admin_tuple
 
-            if admin_structure is None:
-                raise HTTPException(
-                    status_code=500, detail="insert admin_structure failed"
+                background_tasks.add_task(
+                    send_invitation_email,
+                    email=admin_structure.email,
+                    firstname=admin_structure.firstname,
+                    lastname=admin_structure.lastname,
+                    access_key=account.access_key,
                 )
 
-            email_username = data.admin.email.split("@")[0].lower()
+            except InsertFailError as error:
+                logging.error(error)
+                raise HTTPException(
+                    status_code=500,
+                    detail=error,
+                ) from error
 
-            accounts = await get_accounts_with_query(
-                db,
-                """
-                WHERE account.username like $1
-                """,
-                email_username + "%",
-            )
+            except Exception as error:
+                logging.error(error)
+                raise HTTPException(
+                    status_code=500, detail="fail to create admin structure structure"
+                ) from error
+        try:
 
-            username = create_username(
-                email_username, [account.username for account in accounts]
-            )
-
-            account = await insert_admin_structure_account(
+            ass_id: UUID | None = await insert_admin_structure_structure(
                 connection=db,
                 admin_structure_id=admin_structure.id,
-                confirmed=True,
-                username=username,
+                structure_id=data.structure_id,
             )
 
-            if not account:
-                logging.error(f"Insert account failed")
-                raise HTTPException(status_code=500, detail="insert account failed")
+            if not ass_id:
+                logging.error(f"Insert admin_structure_structure failed")
+                raise HTTPException(
+                    status_code=500,
+                    detail="insert admin_structure_structure failed",
+                )
+            return admin_structure
 
-            background_tasks.add_task(
-                send_invitation_email,
-                email=admin_structure.email,
-                firstname=admin_structure.firstname,
-                lastname=admin_structure.lastname,
-                access_key=account.access_key,
+        except UniqueViolationError as error:
+            logging.error(
+                "uniqueness violation fail for insert admin_structure_structure: {}".format(
+                    error
+                )
             )
-
-        ass_id = await insert_admin_structure_structure(
-            connection=db,
-            admin_structure_id=admin_structure.id,
-            structure_id=data.structure_id,
-        )
-
-        if not ass_id:
-            logging.error(f"Insert admin_structure_structure failed")
             raise HTTPException(
-                status_code=500,
-                detail="insert admin_structure_structure failed",
-            )
-
-        return admin_structure
+                status_code=422,
+                detail="duplicate key value violates unique constraint admin_structure_structure_admin_structure_id_structure_id_key",
+            ) from error
+        except Exception as error:
+            logging.error("insert fail {}".format(error))
+            raise HTTPException(
+                status_code=500, detail="fail to create admin structure structure"
+            ) from error
 
 
 def send_invitation_email(
-    email: str, firstname: str | None, lastname: str | None, access_key: uuid.UUID
+    email: str, firstname: str | None, lastname: str | None, access_key: UUID
 ) -> None:
+    """
+    gestion de l'envoi de mail depuis un template
+    """
     message = generic_account_creation_email(email, firstname, lastname, access_key)
     send_mail(email, "Création de compte sur Carnet de bord", message)

--- a/backend/api/v1/routers/admin_structures.py
+++ b/backend/api/v1/routers/admin_structures.py
@@ -94,7 +94,7 @@ async def create_admin_structure(
             )
             raise HTTPException(
                 status_code=422,
-                detail="duplicate key value violates unique constraint admin_structure_structure_admin_structure_id_structure_id_key",
+                detail="impossible to associate given admin with given structure: relationship already exists",
             ) from error
         except Exception as error:
             logging.error("insert fail {}".format(error))

--- a/backend/api/v1/routers/managers.py
+++ b/backend/api/v1/routers/managers.py
@@ -54,7 +54,7 @@ async def create_manager(
             connection=db,
             admin_pdi_id=admin_pdi.id,
             confirmed=True,
-            username=str(uuid.uuid4()),
+            username=username,
         )
 
         if not account:

--- a/backend/tests/api/test_admin_structures.py
+++ b/backend/tests/api/test_admin_structures.py
@@ -132,6 +132,32 @@ async def test_insert_existing_admin_structure_in_structure_in_db(
     assert records[1]["email"] == "vincent.timaitre@groupe-ns.fr"
 
 
+async def test_insert_existing_admin_structure_in_existing_structure(
+    test_client,
+    get_admin_structure_jwt,
+    mocker,
+):
+    mocker.patch(sendmail_path, return_value=True)
+
+    response = test_client.post(
+        api_path,
+        json={
+            "admin": {
+                "email": "vincent.timaitre@groupe-ns.fr ",
+                "firstname": "Vincent",
+                "lastname": "timaitre",
+                "phone_numbers": "0601020304",
+                "position": "responsable",
+                "deployment_id": deployment_id,
+            },
+            "structure_id": "8b71184c-6479-4440-aa89-15da704cc792",
+        },
+        headers={"jwt-token": f"{get_admin_structure_jwt}"},
+    )
+
+    assert response.status_code == 422
+
+
 async def test_background_task(test_client, get_admin_structure_jwt: str, mocker):
     mock: MagicMock = mocker.patch(sendmail_path, return_value=True)
     test_client.post(

--- a/src/lib/services/backend.ts
+++ b/src/lib/services/backend.ts
@@ -7,12 +7,20 @@ export async function postManager(
 	data: { deployment_id: string } & DeploymentAdminPdiType,
 	headers: Record<string, string>
 ) {
-	return post(url, data, headers).then((resp) => resp.json());
+	return post(url, data, headers).then(handleResponse);
 }
 export async function postAdminStructure(
 	url,
 	data: { admin: { deployment_id: string } & AdminStructureAccountInput; structure_id: string },
 	headers: Record<string, string>
 ) {
-	return post(url, data, headers).then((resp) => resp.json());
+	return post(url, data, headers).then(handleResponse);
+}
+
+async function handleResponse(response: Response) {
+	if (response.ok) {
+		return response.json();
+	}
+	const errorMessage = await response.text();
+	return Promise.reject(new Error(errorMessage));
 }

--- a/src/lib/ui/AdminStructure/AddAdminStructureLayer.svelte
+++ b/src/lib/ui/AdminStructure/AddAdminStructureLayer.svelte
@@ -35,6 +35,9 @@
 		} catch (error) {
 			console.error(error);
 			errorMessage = 'Impossible de rajouter cet admin';
+			if (/admin_structure_structure_admin_structure_id_structure_id_key/.test(error)) {
+				errorMessage = 'Cet administrateur est déjà ajouté à cette structure.';
+			}
 		}
 	}
 </script>

--- a/src/lib/ui/AdminStructure/AddAdminStructureLayer.svelte
+++ b/src/lib/ui/AdminStructure/AddAdminStructureLayer.svelte
@@ -35,7 +35,7 @@
 		} catch (error) {
 			console.error(error);
 			errorMessage = 'Impossible de rajouter cet admin';
-			if (/admin_structure_structure_admin_structure_id_structure_id_key/.test(error)) {
+			if (/relationship already exists/.test(error)) {
 				errorMessage = 'Cet administrateur est déjà ajouté à cette structure.';
 			}
 		}


### PR DESCRIPTION
## :wrench: Problème

ETQ gestionnaire de structure, ajouter des co-gestionnaires de structure DÉJA existants

## :cake:  Solution

J'ai modifié le endpoint `/admin_structure/create` pour qu'il verifie si l'admin à créer n'existe pas (en cherchant par email)
Si le pro n'existe pas, on fait comme avant (creation de l'admin structure + creation du compte + envoi de mail) puis création de la relation structure / admin structure
Si le pro existe, on ne crée alors que la relation structure / admin_structure

Les tests pytest ont été modifiés en conséquence

## :rotating_light:  Point d'attention
Si la relation admin_structure / structure existe déjà, il y aura une erreur lors de l'ajout

## :desert_island: Comment tester

Se connecter en tant que jacques.celaire@livry-gargan.fr et aller sur la structure `Centre Communal d'action social Livry-Gargan`
Ajouter un gestionnaire
Saisir les informations suivantes (Vincent, Timaitre, vincent.timaitre@groupe-ns.fr,..) et valider

Vérifier que l'ajout se fait sans erreur.


fix https://github.com/SocialGouv/carnet-de-bord/issues/1057