### PR TITLE
feat: Ajoute la date de naissance dans la liste des bénéficiaires pour un admin.

### DIFF
--- a/e2e/features/manager/showListBeneficiairies.feature
+++ b/e2e/features/manager/showListBeneficiairies.feature
@@ -1,0 +1,13 @@
+#language: fr
+
+@admin_structure_beneficiaries_list_view
+Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
+	En tant que manager
+	Je veux voir la liste des bénéficiaires
+
+	Scénario: voir la liste
+		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Quand je clique sur "Bénéficiaires"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Alors je vois la colonne "Date de naissance"
+		Alors je vois "21/06/1996" dans la colonne "Date de naissance"

--- a/e2e/features/manager/showListBeneficiairies.feature
+++ b/e2e/features/manager/showListBeneficiairies.feature
@@ -8,6 +8,6 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 	Scénario: voir la liste
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
-		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand j'attends que la table "Liste des bénéficiaires" apparaisse
 		Alors je vois la colonne "Date de naissance"
-		Alors je vois "21/06/1996" dans la colonne "Date de naissance"
+		Alors je vois "22/06/1996" sur la ligne "Lindsay"

--- a/e2e/features/manager/viewNotebook.feature
+++ b/e2e/features/manager/viewNotebook.feature
@@ -2,7 +2,7 @@
 
 @manager_notebook_view
 Fonctionnalité: Consultation d'un carnet par un manager
-	En tant que maanger
+	En tant que manager
 	Je veux voir le carnet d'un bénéficiaire
 
 	Scénario: voir un carnet

--- a/e2e/features/structureAdmin/viewNotebook.feature
+++ b/e2e/features/structureAdmin/viewNotebook.feature
@@ -2,7 +2,7 @@
 
 @admin_structure_notebook_view
 Fonctionnalité: Consultation d'un carnet par un manager
-	En tant que maanger
+	En tant que manager
 	Je veux voir le carnet d'un bénéficiaire
 
 	Scénario: voir un carnet

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -300,7 +300,3 @@ After((params) => {
 Alors('je vois la colonne {string}', (text) => {
 	I.seeElement(`//th[contains(., "${text}")]`);
 });
-
-Alors(/^je vois "(.*?)" dans la colonne "(.*?)"$/, (text) => {
-	I.seeElement(`//td[contains(., "${text}")]`);
-});

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -200,8 +200,8 @@ Alors('je vois que bouton {string} est désactivé', (text) => {
 	I.seeElement(`//button[text()="${text}" and @disabled]`);
 });
 
-Alors('je vois {string} fois le {string} {string}', (num, element, text) => {
-	I.seeNumberOfVisibleElements(`//${element}[contains(., "${text}")]`, parseInt(num, 10));
+Alors('je vois {int} fois le {string} {string}', (num, element, text) => {
+	I.seeNumberOfVisibleElements(`//${element}[contains(., "${text}")]`, num);
 });
 
 Alors('je vois {string} suggestions', (num) => {

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -296,3 +296,11 @@ Before(async (params) => {
 After((params) => {
 	setupAfterFixturesByTags(params.tags);
 });
+
+Alors('je vois la colonne {string}', (text) => {
+	I.seeElement(`//th[contains(., "${text}")]`);
+});
+
+Alors(/^je vois "(.*?)" dans la colonne "(.*?)"$/, (text) => {
+	I.seeElement(`//td[contains(., "${text}")]`);
+});

--- a/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -10598,6 +10598,7 @@ export type GetBeneficiariesQuery = {
 		id: string;
 		firstname: string;
 		lastname: string;
+		dateOfBirth: string;
 		beneficiaryInfo?:
 			| {
 					__typename?: 'beneficiary_info';
@@ -14333,6 +14334,7 @@ export const GetBeneficiariesDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'dateOfBirth' } },
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'beneficiaryInfo' },

--- a/src/lib/ui/BeneficiaryList/ListWithStructure.svelte
+++ b/src/lib/ui/BeneficiaryList/ListWithStructure.svelte
@@ -37,6 +37,7 @@
 			<th />
 			<th class="text-left">Nom</th>
 			<th class="text-left">Prénom</th>
+			<th class="text-left">Date de naissance</th>
 			<th class="text-left">Structure</th>
 			<th class="text-left">Référent unique</th>
 			<th class="text-left">Depuis le</th>
@@ -65,6 +66,7 @@
 				</td>
 				<td>{beneficiary.lastname}</td>
 				<td>{beneficiary.firstname}</td>
+				<td>{formatDateLocale(beneficiary.dateOfBirth)}</td>
 				<td>
 					{#if beneficiary.structures.length > 0}
 						{beneficiary.structures[0].structure.name}

--- a/src/lib/ui/BeneficiaryList/_getBeneficiaries.gql
+++ b/src/lib/ui/BeneficiaryList/_getBeneficiaries.gql
@@ -19,6 +19,7 @@ query GetBeneficiaries(
     id
     firstname
     lastname
+    dateOfBirth
     beneficiaryInfo {
       orientation_type {
         id


### PR DESCRIPTION
fixes #984 

## :unicorn: Problème
En tant qu'admin, la date de naissance n'est pas directement accessible dans la liste des bénéficiaires (onglet "bénéficiaires"). 
Il faut, à chaque fois, entrer dans le carnet en lecture pour en prendre connaissance.

## :robot: Solution
On ajoute une colonne date de naissance dans la liste des bénéficiaires.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter avec le compte `manager.cd93`.
Se rendre sur la liste des bénéficiaires (onglet "bénéficiaires").
Constater l'ajout de la colone `Date de naissance`.

![Screen Recording 2022-09-07 at 16 19 08](https://user-images.githubusercontent.com/2989532/188970445-a8dab904-4030-4442-aca7-e25ab104e708.gif)

