### PR TITLE
feat: Extraire la donnée RQTH de la section des "Droits"

### DIFF
--- a/e2e/features/manager/viewNotebook.feature
+++ b/e2e/features/manager/viewNotebook.feature
@@ -13,3 +13,13 @@ Fonctionnalité: Consultation d'un carnet par un manager
 		Quand je vais sur l'onglet suivant
 		Alors j'attends que le texte "Lindsay Aguilar" apparaisse
 		Alors je vois "lindsay.aguilar@nisi.fr"
+
+	Scénario: voir l'information RQTH
+		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Quand je clique sur "Bénéficiaires"
+		Alors j'attends que le titre de page "Bénéficiaires" apparaisse
+		Quand je clique sur "Voir le carnet de Katharine Chandler"
+		Quand je vais sur l'onglet suivant
+		Alors j'attends que le texte "Katharine Chandler" apparaisse
+		Quand je clique sur "Situation socioprofessionnelle"
+		Alors je vois "Usager disposant de la RQTH"

--- a/src/lib/ui/Beneficiary/SocioProView.svelte
+++ b/src/lib/ui/Beneficiary/SocioProView.svelte
@@ -21,31 +21,32 @@
 </script>
 
 <div class="flex flex-col space-y-6">
-	{#if notebook.workSituationDate && notebook.workSituation}
-		<div>
-			<strong>{workSituationKeys.byKey[notebook.workSituation]}</strong>
-			{contractDatesTemplating(notebook.workSituationDate, notebook.workSituationEndDate)}
-			{#if notebook.workSituationEndDate}
-				-
-				<span class="italic font-bold">
-					({dateInterval(notebook.workSituationDate, notebook.workSituationEndDate)})
-				</span>
-			{/if}
-		</div>
-	{/if}
+	<div class="flex flex-row flex-wrap">
+		{#if notebook.workSituationDate && notebook.workSituation}
+			<div class="w-1/2">
+				<strong>{workSituationKeys.byKey[notebook.workSituation]}</strong>
+				{contractDatesTemplating(notebook.workSituationDate, notebook.workSituationEndDate)}
+				{#if notebook.workSituationEndDate}
+					-
+					<span class="italic font-bold">
+						({dateInterval(notebook.workSituationDate, notebook.workSituationEndDate)})
+					</span>
+				{/if}
+			</div>
+		{/if}
+
+		{#if notebook.rightRqth}
+			<Text classNames="w-1/2" value="Usager disposant de la RQTH" />
+		{/if}
+	</div>
 
 	<div class="flex flex-row flex-wrap">
 		<div class="w-1/2">
 			<strong class="text-base text-france-blue">Droits</strong>
 			<Text classNames="mb-2" value={`RSA - ${rsaRightKeys.byKey[notebook.rightRsa]}`} />
-			{#if [notebook.rightRqth, notebook.rightAre, notebook.rightBonus, notebook.rightAss].filter( (field) => Boolean(field) ).length > 0}
+			{#if [notebook.rightAre, notebook.rightBonus, notebook.rightAss].filter( (field) => Boolean(field) ).length > 0}
 				<p>
-					{[
-						notebook.rightRqth && 'RQTH',
-						notebook.rightAre && 'ARE',
-						notebook.rightAss && 'ASS',
-						notebook.rightBonus && 'Bonus',
-					]
+					{[notebook.rightAre && 'ARE', notebook.rightAss && 'ASS', notebook.rightBonus && 'Bonus']
 						.filter((field) => Boolean(field))
 						.join(', ')}
 				</p>

--- a/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
+++ b/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProUpdate.svelte
@@ -205,6 +205,11 @@
 				</div>
 			</div>
 		</div>
+
+		<div class="pb-4">
+			<Checkbox name="rightRqth" label="RQTH" />
+		</div>
+
 		<Radio
 			legend="Revenu de solidarité active (RSA)"
 			name="rightRsa"
@@ -215,7 +220,6 @@
 			<div class="pb-2 font-bold">Autres aides</div>
 			<Checkbox name="rightAre" label="ARE" />
 			<Checkbox name="rightAss" label="ASS" />
-			<Checkbox name="rightRqth" label="RQTH" />
 			<Checkbox name="rightBonus" label="Prime d'activité" />
 		</div>
 

--- a/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProView.svelte
+++ b/src/lib/ui/ProNotebookSocioPro/ProNotebookSocioProView.svelte
@@ -37,33 +37,34 @@
 </script>
 
 <div class="flex flex-col space-y-6">
-	{#if notebook.workSituation}
-		<div>
-			<strong>{workSituationKeys.byKey[notebook.workSituation]}</strong>
-			{#if notebook.workSituationDate}
-				{contractDatesTemplating(notebook.workSituationDate, notebook.workSituationEndDate)}
-				{#if notebook.workSituationEndDate}
-					-
-					<span class="italic font-bold">
-						({dateInterval(notebook.workSituationDate, notebook.workSituationEndDate)})
-					</span>
+	<div class="flex flex-row flex-wrap">
+		{#if notebook.workSituation}
+			<div class="w-1/2">
+				<strong>{workSituationKeys.byKey[notebook.workSituation]}</strong>
+				{#if notebook.workSituationDate}
+					{contractDatesTemplating(notebook.workSituationDate, notebook.workSituationEndDate)}
+					{#if notebook.workSituationEndDate}
+						-
+						<span class="italic font-bold">
+							({dateInterval(notebook.workSituationDate, notebook.workSituationEndDate)})
+						</span>
+					{/if}
 				{/if}
-			{/if}
-		</div>
-	{/if}
+			</div>
+		{/if}
+
+		{#if notebook.rightRqth}
+			<Text classNames="w-1/2" value="Usager disposant de la RQTH" />
+		{/if}
+	</div>
 
 	<div class="flex flex-row flex-wrap">
 		<div class="w-1/2">
 			<strong class="text-base text-france-blue">Droits</strong>
 			<Text classNames="mb-2" value={`RSA - ${rsaRightKeys.byKey[notebook.rightRsa]}`} />
-			{#if [notebook.rightRqth, notebook.rightAre, notebook.rightBonus, notebook.rightAss].filter( (field) => Boolean(field) ).length > 0}
+			{#if [notebook.rightAre, notebook.rightBonus, notebook.rightAss].filter( (field) => Boolean(field) ).length > 0}
 				<p>
-					{[
-						notebook.rightRqth && 'RQTH',
-						notebook.rightAre && 'ARE',
-						notebook.rightAss && 'ASS',
-						notebook.rightBonus && 'Bonus',
-					]
+					{[notebook.rightAre && 'ARE', notebook.rightAss && 'ASS', notebook.rightBonus && 'Bonus']
 						.filter((field) => Boolean(field))
 						.join(', ')}
 				</p>


### PR DESCRIPTION
closes #1066 

## :wrench: Problème

La RQTH est une décision administrative permettant - entre d'autre - d'être concerné par l' "obligation d'emploi" des personnes handicapées incombant aux entreprises. 
Ce n'est pas une aide alors qu'aujourd'hui elle figure dans les "Droits" sur le carnet et peut être sélectionnée parmi les "Autres aides".

## :cake: Solution

Déplacer la donnée RQTH sur le carnet pour : 
  - qu'elle apparaisse à côté de la situation socioprofessionnelle
   - qu'elle puisse être sélectionnable indépendamment des autres aides dans le volet latéral "Mettre à jour"

## :rotating_light:  Points d'attention / Remarques

Quand la situation socioprofessionnelle n'est pas renseignée, la section concernant la donnée RQTH est affichée à gauche pour éviter un blanc (voir le gif).

## :desert_island: Comment tester

Se connecter en tant que chargé d'orientation avec le compte 'giulia.diaby@cd93.fr'.
Affecter le bénéficiaire `Noel Keller` en cliquant sur `Non assigné` puis en sélectionnant `Giulia Diaby`.
Afficher le carnet du bénéficiaire `Noel Keller`.
Vérifier dans le carnet l'affichage du texte `Usager disposant de la RQTH` dans la section `Situation socioprofessionnelle`.
Cliquer sur le bouton `Mettre à jour`.
Verifier que la case à cocher `RQTH` est affichée seule après la situation actuelle et avant la section `Revenu de solidarité active (RSA)`

## 🛎️ Résultat

![Screen Recording 2022-09-08 at 16 49 53](https://user-images.githubusercontent.com/2989532/189224675-3afd87f2-1b7e-41d7-9c33-0b684c2f958d.gif)


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
