### PR TITLE
fix: correction du type de creator_id

### DIFF
--- a/backend/api/db/models/notebook_member.py
+++ b/backend/api/db/models/notebook_member.py
@@ -11,7 +11,7 @@ class NotebookMemberInsert(BaseModel):
     last_visited_at: datetime | None = None
     member_type: str
     last_modified_at: datetime | None = None
-    creator_id: datetime | None = None
+    creator_id: UUID | None = None
     invitation_sent_at: datetime | None = None
     active: bool | None = None
 

--- a/hasura/seeds/carnet_de_bord/seed-data.sql
+++ b/hasura/seeds/carnet_de_bord/seed-data.sql
@@ -307,7 +307,7 @@ INSERT INTO public.account (id, username, type, professional_id, confirmed, onbo
 
 INSERT INTO public.orientation_manager (id, email, lastname, firstname, phone_numbers, deployment_id) VALUES ('607cb6f8-9e33-4ce8-98b1-38e60c9dda99', 'giulia.diaby@cd93.fr', 'Diaby', 'Giulia', '0912345678, 0612345678', '4dab8036-a86e-4d5f-9bd4-6ce88c1940d0');
 INSERT INTO public.account (id, username, type, orientation_manager_id, confirmed, onboarding_done) VALUES ('2addd10f-9bd3-4d37-b3c9-10a6e2c4be4f', 'giulia.diaby', 'orientation_manager', '607cb6f8-9e33-4ce8-98b1-38e60c9dda99', true, false);
-INSERT INTO public.notebook_member (id, notebook_id, account_id, last_visited_at, member_type, created_at, creator_id, invitation_sent_at) VALUES ('b712740e-74da-4b0b-96c8-d689be164807', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', '2addd10f-9bd3-4d37-b3c9-10a6e2c4be4f', '2021-09-21 13:06:45.076+00', 'referent', '2021-09-21 11:51:37.295647+00', NULL, NULL);
+INSERT INTO public.notebook_member (id, notebook_id, account_id, last_visited_at, member_type, created_at, creator_id, invitation_sent_at) VALUES ('b712740e-74da-4b0b-96c8-d689be164807', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', '2addd10f-9bd3-4d37-b3c9-10a6e2c4be4f', '2021-09-21 13:06:45.076+00', 'referent', '2021-09-21 11:51:37.295647+00', '9eee9fea-bf3e-4eb8-8f43-d9b7fd6fae76', NULL);
 
 
 INSERT INTO public.notebook_focus (id, theme, situations, creator_id, notebook_id, created_at, linked_to) VALUES ('a55d1dd2-2b09-4456-bcc5-1412695f684f', 'logement', '["Hébergé chez un tiers"]', '2addd10f-9bd3-4d37-b3c9-10a6e2c4be4f', '9b07a45e-2c7c-4f92-ae6b-bc2f5a3c9a7d', '2021-09-21 13:15:54.752334+00', 'cer');


### PR DESCRIPTION
## :wrench: Problème

Lors de l'exécution du script d'export Vitamine, une erreur met en évidence un mauvais typage Python.

## :cake: Solution

Modification du type Python et mise à jour des fixtures pour reproduire le souci.

## :desert_island: Comment tester

`poetry run python scripts/export_notebook.py 1c52e5ad-e0b9-48b9-a490-105a4effaaea` devrait s'exécuter avec succès et produire un JSON sur stdout.
