### PR TITLE
ci: add a notification on Mattermost

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Find matching workflow
-        uses: SamhammerAG/last-successful-build-action@v2
+        uses: SamhammerAG/last-successful-build-action@a54c030
         id: latest-deployment
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,0 +1,42 @@
+name: Test notification on tag
+
+on:
+  push:
+    tags:
+      - test.*
+
+jobs:
+  test-notification:
+    name: Notify mattermost channel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Find matching workflow
+        uses: SamhammerAG/last-successful-build-action@v2
+        id: latest-deployment
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: "Production"
+          verify: true
+      - name: Extract changelog content
+        id: extract-changelog
+        run: |
+          CHANGELOG_CONTENT=$(cat << EOF
+          $(git diff --output-indicator-new='*' ${{ steps.latest-deployment.outputs.sha }}...${{ github.sha }} CHANGELOG.md | egrep '^\*' | cut -c 2-)
+          EOF
+          )
+          # replace new lines and carriage returns
+          CHANGELOG_CONTENT="${CHANGELOG_CONTENT//'%'/'%25'}"
+          CHANGELOG_CONTENT="${CHANGELOG_CONTENT//$'\n'/'%0A'}"
+          CHANGELOG_CONTENT="${CHANGELOG_CONTENT//$'\r'/'%0D'}"
+          echo "::set-output name=content::$CHANGELOG_CONTENT"
+      - name: Create the deployment message
+        run: |
+          echo "{\"text\":\":tada: **${{ github.ref_name }} en production**\n${{ steps.extract-changelog.outputs.content }}\"}" > mattermost.json
+      - name: Notify deployment on Mattermost
+        uses: mattermost/action-mattermost-notify@master
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          MATTERMOST_CHANNEL: startup-carnetdebord-deploiements

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Find matching workflow
-        uses: SamhammerAG/last-successful-build-action@v2
+        uses: SamhammerAG/last-successful-build-action@a54c030
         id: latest-deployment
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -78,3 +78,33 @@ jobs:
           kubeconfig: ${{ secrets.KUBECONFIG }}
           rancherProjectId: ${{ secrets.RANCHER_PROJECT_ID }}
           rancherProjectName: ${{ secrets.RANCHER_PROJECT_NAME }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Find matching workflow
+        uses: SamhammerAG/last-successful-build-action@v2
+        id: latest-deployment
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          workflow: "Production"
+          verify: true
+      - name: Extract changelog content
+        id: extract-changelog
+        run: |
+          CHANGELOG_CONTENT=$(cat << EOF
+          $(git diff --output-indicator-new='*' ${{ steps.latest-deployment.outputs.sha }}...${{ github.sha }} CHANGELOG.md | egrep '^\*' | cut -c 2-)
+          EOF
+          )
+          # replace new lines and carriage returns
+          CHANGELOG_CONTENT="${CHANGELOG_CONTENT//'%'/'%25'}"
+          CHANGELOG_CONTENT="${CHANGELOG_CONTENT//$'\n'/'%0A'}"
+          CHANGELOG_CONTENT="${CHANGELOG_CONTENT//$'\r'/'%0D'}"
+          echo "::set-output name=content::$CHANGELOG_CONTENT"
+      - name: Create the deployment message
+        run: |
+          echo "{\"text\":\":tada: **${{ github.ref_name }} en production**\n${{ steps.extract-changelog.outputs.content }}\"}" > mattermost.json
+      - name: Notify deployment on Mattermost
+        uses: mattermost/action-mattermost-notify@master
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          MATTERMOST_CHANNEL: startup-carnetdebord-deploiements


### PR DESCRIPTION
## :wrench: Problème

On met en production régulièrement et il est parfois compliqué de suivre le rythme et le contenu des déploiements côté produit.

## :cake: Solution

On ajoute une étape d'envoi de message vers Mattermost à chaque succès du worklfow de déploiement en production.

## :rotating_light:  Points d'attention / Remarques

Le webhook utilisé poste les messages dans le canal `~startup-carnetdebord-deploiments`, en incluant le contenu du CHANGELOG ajouté depuis le dernier déploiement en production.

A voir si cela convient à l'usage.

## :desert_island: Comment tester

Un premier test a été fait en exécutant l'action GitHub :


<img width="560" alt="Screenshot 2022-09-16 at 08 27 05" src="https://user-images.githubusercontent.com/2989532/190638642-7b8296f8-49d5-47d3-be17-ad1278f02957.png">


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
