### PR TITLE
fix: ajout de sentry aux scripts python

### DIFF
--- a/backend/scripts/export_notebook.py
+++ b/backend/scripts/export_notebook.py
@@ -3,6 +3,7 @@ import json
 import logging
 from uuid import UUID
 
+import sentry_sdk
 import typer
 from asyncpg.connection import Connection
 
@@ -12,6 +13,8 @@ from api.db.crud.notebook import get_notebooks_by_structure_id
 from api.db.crud.out import notebook_to_out
 from api.db.models.notebook import Notebook
 from api.db.models.out import NotebookOut
+
+sentry_sdk.init()
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 

--- a/backend/scripts/parse_csv_pe.py
+++ b/backend/scripts/parse_csv_pe.py
@@ -1,8 +1,11 @@
 import asyncio
 
+import sentry_sdk
 import typer
 
 from cdb_csv import pe
+
+sentry_sdk.init()
 
 app = typer.Typer()
 


### PR DESCRIPTION
## :wrench: Problème

Actuellement les erreurs des scripts ne sont pas remontées dans Sentry.

## :cake: Solution

Initialiser Sentry au début de l'appel du script.


## :rotating_light:  Points d'attention / Remarques

Seuls les scripts `export_notebook.py` et `parse_csv_pe.py` sont appelés sur la production.

## :desert_island: Comment tester

À discuter

fix #1085 