### PR TITLE
feat: filter beneficiary list with a  notebook member

### DIFF
--- a/e2e/features/manager/showListBeneficiairies.feature
+++ b/e2e/features/manager/showListBeneficiairies.feature
@@ -5,9 +5,25 @@ Fonctionnalité: Consultation de la liste des bénéficiaires par un manager
 	En tant que manager
 	Je veux voir la liste des bénéficiaires
 
-	Scénario: voir la liste
+	Scénario: Voir la liste
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Bénéficiaires"
 		Quand j'attends que la table "Liste des bénéficiaires" apparaisse
 		Alors je vois la colonne "Date de naissance"
 		Alors je vois "22/06/1996" sur la ligne "Lindsay"
+
+	Scénario: Voir la liste des bénéficiaires d'un professionnel
+		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Quand je clique sur "Professionnels"
+		Quand je clique sur "liste des bénéficiaires de Pierre Chevalier"
+		Alors je vois "pierre.chevalier@livry-gargan.fr"
+		Alors je vois "Supprimer le filtre"
+		Alors je vois "Tifour" dans le tableau "Liste des bénéficiaires"
+
+	Scénario: Supprimer le filtre professionnel
+		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Quand je clique sur "Professionnels"
+		Quand je clique sur "liste des bénéficiaires de Pierre Chevalier"
+		Quand je clique sur "Supprimer le filtre"
+		Alors je ne vois pas "Supprimer le filtre"
+		Alors je vois "Aguilar" dans le tableau "Liste des bénéficiaires"

--- a/e2e/features/manager/showListProfessionals.feature
+++ b/e2e/features/manager/showListProfessionals.feature
@@ -17,5 +17,5 @@ Fonctionnalité: Consultation de la liste des professionnels par un administrate
 		Alors je vois la colonne "BRSA suivis"
 		Alors je vois "pierre.chevalier@livry-gargan.fr" sur la ligne "Pierre Chevalier"
 		Alors je vois "01 41 70 88 00" sur la ligne "Pierre Chevalier"
-		Alors je vois "Oui" sur la ligne "Pierre Chevalier"
+		Alors je vois "Fait" sur la ligne "Pierre Chevalier"
 		Alors je vois "1" sur la ligne "Pierre Chevalier"

--- a/e2e/features/manager/validateAccount.feature
+++ b/e2e/features/manager/validateAccount.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Gestion de professionnels d'un déploiement
 	En tant que manager d'un déploiement
 	Je veux pouvoir voir les professionnels et gérer leur activation
 
-	Scénario: Liste des professionnel
+	Scénario: Liste des professionnels
 		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
 		Quand je clique sur "Professionnels"
 		Quand j'attends que la table "Liste des professionnels" apparaisse

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"@babel/core": "^7.16.5",
 		"@babel/preset-env": "^7.16.5",
 		"@babel/preset-typescript": "^7.16.5",
-		"@gouvfr/dsfr": "^1.6.0",
+		"@gouvfr/dsfr": "^1.7.2",
 		"@urql/core": "^2.3.6",
 		"@urql/svelte": "^1.3.3",
 		"cookie": "^0.5.0",

--- a/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/src/lib/ui/BeneficiaryList/Container.svelte
@@ -47,6 +47,7 @@
 				notebook: {
 					...(member && {
 						members: {
+							active: { _eq: true },
 							account: {
 								_or: [
 									{ professional: { email: { _eq: member } } },
@@ -65,6 +66,8 @@
 				notebook: {
 					members: {
 						...(member && {
+							active: { _eq: true },
+
 							account: {
 								_or: [
 									{ professional: { email: { _eq: member } } },
@@ -83,6 +86,8 @@
 			notebook: {
 				...(member && {
 					members: {
+						active: { _eq: true },
+
 						account: {
 							_or: [
 								{ professional: { email: { _eq: member } } },

--- a/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/src/lib/ui/BeneficiaryList/Container.svelte
@@ -41,53 +41,12 @@
 	type Beneficiary = GetBeneficiariesQuery['beneficiaries'][0];
 
 	function getWithMemberFilter(filter: MemberFilter): BeneficiaryBoolExp {
-		if (filter === 'noMember') {
-			return {
-				...(structureId && { structures: { structureId: { _eq: structureId } } }),
-				notebook: {
-					...(member && {
-						members: {
-							active: { _eq: true },
-							account: {
-								_or: [
-									{ professional: { email: { _eq: member } } },
-									{ orientation_manager: { email: { _eq: member } } },
-								],
-							},
-						},
-					}),
-					_or: [{ _not: { members: {} } }, { members: { active: { _eq: false } } }],
-				},
-			};
-		}
-		if (filter === 'withMember') {
-			return {
-				...(structureId && { structures: { structureId: { _eq: structureId } } }),
-				notebook: {
-					members: {
-						...(member && {
-							active: { _eq: true },
-
-							account: {
-								_or: [
-									{ professional: { email: { _eq: member } } },
-									{ orientation_manager: { email: { _eq: member } } },
-								],
-							},
-						}),
-						active: { _eq: true },
-						memberType: { _eq: 'referent' },
-					},
-				},
-			};
-		}
-		return {
+		const graphqlFilter: BeneficiaryBoolExp = {
 			...(structureId && { structures: { structureId: { _eq: structureId } } }),
 			notebook: {
 				...(member && {
 					members: {
 						active: { _eq: true },
-
 						account: {
 							_or: [
 								{ professional: { email: { _eq: member } } },
@@ -98,6 +57,21 @@
 				}),
 			},
 		};
+
+		if (filter === 'noMember') {
+			graphqlFilter.notebook._or = [
+				{ _not: { members: {} } },
+				{ members: { active: { _eq: false } } },
+			];
+		}
+		if (filter === 'withMember') {
+			graphqlFilter.notebook.members = {
+				...graphqlFilter.notebook.members,
+				active: { _eq: true },
+				memberType: { _eq: 'referent' },
+			};
+		}
+		return graphqlFilter;
 	}
 
 	const result = operationStore(

--- a/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/src/lib/ui/BeneficiaryList/Container.svelte
@@ -178,7 +178,7 @@
 			},
 		});
 	}
-
+	$: nbBeneficiaries = $result.data?.search_beneficiaries_aggregate.aggregate.count ?? 0;
 	$: nbSelectedBeneficiaries = Object.keys($selectionStore).length;
 </script>
 
@@ -193,11 +193,7 @@
 			<BeneficiaryListWithOrientation beneficiaries={$result.data.beneficiaries} />
 		{/if}
 		<div class="flex justify-center">
-			<Pagination
-				{currentPage}
-				{pageSize}
-				count={$result.data.search_beneficiaries_aggregate.aggregate.count}
-			/>
+			<Pagination {currentPage} {pageSize} count={nbBeneficiaries} />
 		</div>
 	</LoaderIndicator>
 	{#if nbSelectedBeneficiaries > 0}

--- a/src/lib/ui/BeneficiaryList/Container.svelte
+++ b/src/lib/ui/BeneficiaryList/Container.svelte
@@ -59,10 +59,9 @@
 		};
 
 		if (filter === 'noMember') {
-			graphqlFilter.notebook._or = [
-				{ _not: { members: {} } },
-				{ members: { active: { _eq: false } } },
-			];
+			graphqlFilter.notebook = {
+				_or: [{ _not: { members: {} } }, { members: { active: { _eq: false } } }],
+			};
 		}
 		if (filter === 'withMember') {
 			graphqlFilter.notebook.members = {

--- a/src/lib/ui/BeneficiaryList/Filters.svelte
+++ b/src/lib/ui/BeneficiaryList/Filters.svelte
@@ -20,10 +20,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	import { Select } from '$lib/ui/base';
+	import { Button, Select } from '$lib/ui/base';
 
 	export let filter: string;
 	export let search: string;
+	export let member: string;
 
 	const dispatch = createEventDispatcher();
 
@@ -39,6 +40,9 @@
 
 	function updateFilters(event: CustomEvent<{ selected: MemberFilter }>) {
 		dispatch('filter-update', { filter: event.detail.selected, search: search.trim() });
+	}
+	function removeMemberFilter() {
+		dispatch('filter-update', { resetMember: true, filter, search });
 	}
 </script>
 
@@ -67,4 +71,16 @@
 			<button class="fr-btn"> Rechercher </button>
 		</div>
 	</div>
+	{#if member}
+		<p class="flex items-center gap-4 font-medium fr-mt-2w">
+			<span>
+				{member}
+			</span>
+			<Button
+				icon="fr-icon-close-line"
+				on:click={removeMemberFilter}
+				classNames="fr-btn fr-btn--tertiary-no-outline fr-btn--sm">Supprimer le filtre</Button
+			>
+		</p>
+	{/if}
 </form>

--- a/src/lib/ui/Dialog.svelte
+++ b/src/lib/ui/Dialog.svelte
@@ -101,7 +101,7 @@
 
 <style>
 	:global([data-svelte-dialog-overlay]) {
-		z-index: 200;
+		z-index: 500;
 	}
 
 	:global([data-svelte-dialog-content]) {

--- a/src/lib/ui/LayerCDB.svelte
+++ b/src/lib/ui/LayerCDB.svelte
@@ -18,7 +18,7 @@
 
 <svelte:window on:keydown={handleKeyDown} />
 {#if currentLayer}
-	<div transition:fade on:click={close} class="!m-0 z-1 fixed inset-0">
+	<div transition:fade on:click={close} class="!m-0 fixed inset-0 layer">
 		<div class="absolute inset-0 bg-black opacity-50" tabindex="0" />
 	</div>
 {/if}
@@ -26,7 +26,7 @@
 {#if currentLayer}
 	<div
 		transition:fly={{ duration: 300, x: 300 }}
-		class="!m-0 top-0 right-0 w-1/2 bg-white fixed h-full overflow-y-scroll layer overscroll-contain"
+		class="!m-0 top-0 right-0 w-1/2 bg-white fixed h-full overflow-y-scroll overscroll-contain layer"
 	>
 		<div class="flex flex-col gap-6 mx-14 mt-28 mb-14" role="dialog" tabindex="-1">
 			<svelte:component this={currentLayer.component} {...currentLayer.props} />
@@ -43,6 +43,6 @@
 
 <style>
 	.layer {
-		z-index: 1;
+		z-index: 500;
 	}
 </style>

--- a/src/lib/ui/Pagination.svelte
+++ b/src/lib/ui/Pagination.svelte
@@ -3,45 +3,53 @@
 
 	export let pageSize = 20;
 	export let count = 0;
-	export let currentPage = 0;
+	export let currentPage = 1;
 	export let nbVisible = 4;
 
 	const TOLERANCE = 2;
-	const nbPages = Math.ceil(count / pageSize);
+
+	$: nbPages = Math.ceil(count / pageSize);
 
 	function getPaginationHref(pageIndex: number): string {
 		const urlParams = new URLSearchParams([...$page.url.searchParams.entries()]);
 		urlParams.set('page', pageIndex.toString());
 		return `?${urlParams.toString()}`;
 	}
-	let rangeStartIndex = Math.min(
-		Math.max(0, currentPage - Math.floor(nbVisible / 2)),
-		Math.max(nbPages - nbVisible - 1, 0)
-	);
 
-	// prevent "..." from displaying if startRange is too close from the beginn
-	if (rangeStartIndex <= TOLERANCE) {
-		rangeStartIndex = 0;
-	}
-	let rangeEndIndex = Math.min(rangeStartIndex + nbVisible, nbPages);
+	let paginationButtons = [];
 
-	// prevent "..." from displaying if endRange is too close from the end
-	const endRangeNbPageDiff = nbPages - rangeEndIndex;
-	if (endRangeNbPageDiff <= TOLERANCE) {
-		rangeEndIndex += endRangeNbPageDiff;
-	}
-	const paginationButtons = [];
+	$: {
+		paginationButtons = [];
 
-	if (rangeStartIndex > TOLERANCE) {
-		paginationButtons.push(1, null);
-	}
+		let rangeStartIndex = Math.min(
+			Math.max(0, currentPage - Math.floor(nbVisible / 2)),
+			Math.max(nbPages - nbVisible - 1, 0)
+		);
 
-	for (let i = rangeStartIndex; i < rangeEndIndex; i++) {
-		paginationButtons.push(i + 1);
-	}
+		// prevent "..." from displaying if startRange is too close from the beginn
+		if (rangeStartIndex <= TOLERANCE) {
+			rangeStartIndex = 0;
+		}
+		let rangeEndIndex = Math.min(rangeStartIndex + nbVisible, nbPages);
 
-	if (nbPages - rangeEndIndex > TOLERANCE) {
-		paginationButtons.push(null, nbPages);
+		// prevent "..." from displaying if endRange is too close from the end
+		const endRangeNbPageDiff = nbPages - rangeEndIndex;
+
+		if (endRangeNbPageDiff <= TOLERANCE) {
+			rangeEndIndex += endRangeNbPageDiff;
+		}
+
+		if (rangeStartIndex > TOLERANCE) {
+			paginationButtons.push(1, null);
+		}
+
+		for (let i = rangeStartIndex; i < rangeEndIndex; i++) {
+			paginationButtons.push(i + 1);
+		}
+
+		if (nbPages - rangeEndIndex > TOLERANCE) {
+			paginationButtons.push(null, nbPages);
+		}
 	}
 </script>
 

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { GetProfessionalsForStructureQuery } from '$lib/graphql/_gen/typed-document-nodes';
+
 	import { displayFullName } from '../format';
 	type Professional = GetProfessionalsForStructureQuery['professional'][0];
 
@@ -28,12 +29,14 @@
 				<td>{professional.email}</td>
 				<td>{professional.account.onboardingDone ? 'Oui' : 'Non'}</td>
 				<td class="flex justify-end">
-					<button
-						class="fr-tag fr-tag-sm cursor-default"
+					<a
+						href={`beneficiaires?member=${professional.email}`}
+						title={`liste des bénéficiaires de ${professional.firstname} ${professional.lastname}`}
+						class="fr-tag fr-tag-sm"
 						class:fr-tag--purple-glycine={hasNoBeneficiaries}
 					>
 						{beneficiariesCount}
-					</button>
+					</a>
 				</td>
 			</tr>
 		{/each}

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -27,7 +27,7 @@
 				<td>{displayFullName(professional)}</td>
 				<td>{professional.mobileNumber ?? '--'}</td>
 				<td>{professional.email}</td>
-				<td>{professional.account.onboardingDone ? 'Oui' : 'Non'}</td>
+				<td>{professional.account.onboardingDone ? 'Fait' : 'Non fait'}</td>
 				<td class="flex justify-end">
 					<a
 						href={`beneficiaires?member=${professional.email}`}

--- a/src/routes/manager/beneficiaires/index.svelte
+++ b/src/routes/manager/beneficiaires/index.svelte
@@ -8,6 +8,7 @@
 				currentPage: parseInt(params.get('page') ?? '1', 10),
 				filter: getFilter(params.get('filter')),
 				search: params.get('search') ?? '',
+				member: params.get('member'),
 			},
 		};
 	};
@@ -28,6 +29,7 @@
 	export let search: string;
 	export let filter: MemberFilter;
 	export let currentPage: number;
+	export let member: string;
 
 	let breadcrumbs = [
 		{
@@ -49,4 +51,4 @@
 </svelte:head>
 <Breadcrumbs segments={breadcrumbs} />
 <h1>Bénéficiaires</h1>
-<Container listType="manager" {filter} {search} {currentPage} />
+<Container listType="manager" {filter} {search} {currentPage} {member} />

--- a/src/routes/manager/professionnels/index.svelte
+++ b/src/routes/manager/professionnels/index.svelte
@@ -23,6 +23,7 @@
 </script>
 
 <script lang="ts">
+	import { baseUrlForRole } from '$lib/routes';
 	import { Button, IconButton } from '$lib/ui/base';
 	import { displayFullName } from '$lib/ui/format';
 	import { Text } from '$lib/ui/utils';
@@ -160,7 +161,12 @@
 								class:fr-badge--brown-caramel={account.nbBeneficiaries === 0}
 								class:fr-badge--blue-ecume={account.nbBeneficiaries > 0}
 							>
-								{account.nbBeneficiaries}
+								<a
+									href={`${baseUrlForRole(RoleEnum.Manager)}/beneficiaires?member=${account.email}`}
+									title={`liste des bénéficiaires de ${account.firstname} ${account.lastname}`}
+								>
+									{account.nbBeneficiaries}
+								</a>
 							</p>
 						</td>
 						<td class="text-center">

--- a/src/routes/manager/professionnels/index.svelte
+++ b/src/routes/manager/professionnels/index.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script lang="ts">
 	import { post } from '$lib/utils/post';
 	import {
 		GetAccountsSummaryQuery,
@@ -6,37 +6,29 @@
 		RoleEnum,
 	} from '$lib/graphql/_gen/typed-document-nodes';
 	import { GetAccountsSummaryDocument } from '$lib/graphql/_gen/typed-document-nodes';
-	import type { Load } from '@sveltejs/kit';
-	import { OperationStore, query } from '@urql/svelte';
+	import { query } from '@urql/svelte';
 	import { operationStore } from '@urql/svelte';
 	import LoaderIndicator from '$lib/ui/utils/LoaderIndicator.svelte';
 
-	export const load: Load = async () => {
-		const result = operationStore(GetAccountsSummaryDocument, {});
-
-		return {
-			props: {
-				result,
-			},
-		};
-	};
-</script>
-
-<script lang="ts">
 	import { baseUrlForRole } from '$lib/routes';
 	import { Button, IconButton } from '$lib/ui/base';
 	import { displayFullName } from '$lib/ui/format';
 	import { Text } from '$lib/ui/utils';
-	export let result: OperationStore<GetAccountsSummaryQuery>;
 
-	query(result);
+	const proStore = operationStore(
+		GetAccountsSummaryDocument,
+		{},
+		{ additionalTypenames: ['notebook_member'] }
+	);
+
+	query(proStore);
 
 	let accounts: AccountSummary[];
-	$: accounts = $result.data?.accounts.map(toList) || [];
+	$: accounts = $proStore.data?.accounts.map(toList) || [];
 
 	async function confirmAccount(id: string) {
 		await post(`/manager/confirmPro`, { id });
-		$result.reexecute({ requestPolicy: 'network-only' });
+		$proStore.reexecute({ requestPolicy: 'network-only' });
 	}
 
 	let emails: Record<string, undefined | 'ToConfirm' | 'Sending' | 'Failed' | 'Sent'> = {};
@@ -118,7 +110,7 @@
 	<title>Gestion des professionnels - Carnet de bord</title>
 </svelte:head>
 
-<LoaderIndicator {result}>
+<LoaderIndicator result={proStore}>
 	<div class={`w-full fr-table fr-table--layout-fixed fr-mt-6w`}>
 		<table>
 			<caption class="sr-only">Liste des professionnels</caption>

--- a/src/routes/manager/professionnels/index.svelte
+++ b/src/routes/manager/professionnels/index.svelte
@@ -129,6 +129,7 @@
 			</thead>
 			<tbody>
 				{#each accounts as account (account.id)}
+					{@const hasNoBeneficiary = account.nbBeneficiaries === 0}
 					<tr>
 						<td>
 							<Text value={displayFullName(account)} />
@@ -148,18 +149,14 @@
 							<Text value={account.onboardingDone ? 'Fait' : 'Pas fait'} />
 						</td>
 						<td class="text-right">
-							<p
-								class="fr-badge"
-								class:fr-badge--brown-caramel={account.nbBeneficiaries === 0}
-								class:fr-badge--blue-ecume={account.nbBeneficiaries > 0}
+							<a
+								href={`${baseUrlForRole(RoleEnum.Manager)}/beneficiaires?member=${account.email}`}
+								title={`liste des bénéficiaires de ${account.firstname} ${account.lastname}`}
+								class="fr-tag fr-tag-sm"
+								class:fr-tag--purple-glycine={hasNoBeneficiary}
 							>
-								<a
-									href={`${baseUrlForRole(RoleEnum.Manager)}/beneficiaires?member=${account.email}`}
-									title={`liste des bénéficiaires de ${account.firstname} ${account.lastname}`}
-								>
-									{account.nbBeneficiaries}
-								</a>
-							</p>
+								{account.nbBeneficiaries}
+							</a>
 						</td>
 						<td class="text-center">
 							{#if !account.confirmed}

--- a/src/routes/orientation/index.svelte
+++ b/src/routes/orientation/index.svelte
@@ -8,6 +8,7 @@
 				currentPage: parseInt(params.get('page') ?? '1', 10),
 				filter: getFilter(params.get('filter')),
 				search: params.get('search') ?? '',
+				member: params.get('member'),
 			},
 		};
 	};
@@ -28,6 +29,7 @@
 	export let search: string;
 	export let filter: MemberFilter;
 	export let currentPage: number;
+	export let member: string;
 
 	let breadcrumbs = [
 		{
@@ -49,4 +51,4 @@
 </svelte:head>
 <Breadcrumbs segments={breadcrumbs} />
 <h1>Orientation des bénéficiaires</h1>
-<Container listType="orientation" {filter} {search} {currentPage} />
+<Container listType="orientation" {filter} {search} {currentPage} {member} />

--- a/src/routes/structures/[uuid]/beneficiaires.svelte
+++ b/src/routes/structures/[uuid]/beneficiaires.svelte
@@ -10,6 +10,7 @@
 				currentPage: parseInt(searchParams.get('page') ?? '1', 10),
 				filter: getFilter(searchParams.get('filter')),
 				search: searchParams.get('search') ?? '',
+				member: searchParams.get('member'),
 			},
 		};
 	};
@@ -33,6 +34,7 @@
 	export let filter: MemberFilter;
 	export let currentPage: number;
 	export let structureId: string;
+	export let member: string;
 
 	const getStructure = operationStore(GetStructureDocument, { structureId });
 	query(getStructure);
@@ -64,4 +66,4 @@
 </svelte:head>
 <Breadcrumbs segments={breadcrumbs} />
 <h1>Bénéficiaires</h1>
-<Container listType="structure" {structureId} {filter} {search} {currentPage} />
+<Container listType="structure" {structureId} {filter} {search} {currentPage} {member} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,10 +1050,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gouvfr/dsfr@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@gouvfr/dsfr/-/dsfr-1.6.0.tgz#94b9b2837489969d9e1f64bdd0cf6ee3a2f1fa3b"
-  integrity sha512-1d/Uh9xqMWYGYG+/Zb5eg2lROB8MFq0Dy2G000/L8qAWi/LjQaX27U3TfCGwQ5l34Pna6x2/HV74foeIfsoaGA==
+"@gouvfr/dsfr@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@gouvfr/dsfr/-/dsfr-1.7.2.tgz#c522fce21a14989a10e30583160118c39c9c05d1"
+  integrity sha512-hPNtz+gHcc8m7ZPANxSOFMz4Ap+M9FHOudqoMR/+Kjl5FCOqwA6u/aoYnMJ8KqedS1k5XThFMp7jiktr53qXYw==
 
 "@graphql-codegen/cli@^2.3.0":
   version "2.6.2"


### PR DESCRIPTION
fix #769

## :wrench: Problème

En tant que manager, je souhaiterai pouvoir voir la liste des bénéficiaires rattachés à un pro

## :cake: Solution

Créer un filtre pour voir les beneficiaire d'un pro. Pour cela j'ai rajouté un parametre d'url nommé   `member`  qui prend un email comme valeur.

## :rotating_light:  Points d'attention / Remarques

Le filtre fonctionne pour des pro ou des chargé d'orientation

## :desert_island: Comment tester

Se connecter en tant `manager.cd93`, cliquer sur le menu "Professionnel" puis cliquer sur la pastille contenant le nombre de bénéficiaires rattachés à un pro

![image](https://user-images.githubusercontent.com/160320/190197871-3dd16694-94b4-44d9-b07c-5696422c1c53.png)

