### PR TITLE
feat: [Gestionnaire de structure] Afficher la liste des professionnels d'une structure.

### DIFF
--- a/e2e/features/manager/showListProfessionals.feature
+++ b/e2e/features/manager/showListProfessionals.feature
@@ -1,0 +1,21 @@
+#language: fr
+
+@admin_structure_professionals_list_view
+Fonctionnalité: Consultation de la liste des professionnels par un administrateur de structure
+	En tant qu'administrateur de structure
+	Je veux voir la liste des professionnels de la structure
+
+	Scénario: voir la liste
+		Soit un "administrateur de structures" authentifié avec l'email "jacques.celaire@livry-gargan.fr"
+		Quand je clique sur "Centre Communal d'action social Livry-Gargan"
+		Quand je clique sur "Professionnels"
+		Quand j'attends que la table "Liste des professionnels" apparaisse
+		Alors je vois la colonne "Prénom nom"
+		Alors je vois la colonne "Téléphone"
+		Alors je vois la colonne "Email"
+		Alors je vois la colonne "Onboarding"
+		Alors je vois la colonne "BRSA suivis"
+		Alors je vois "pierre.chevalier@livry-gargan.fr" sur la ligne "Pierre Chevalier"
+		Alors je vois "01 41 70 88 00" sur la ligne "Pierre Chevalier"
+		Alors je vois "Oui" sur la ligne "Pierre Chevalier"
+		Alors je vois "1" sur la ligne "Pierre Chevalier"

--- a/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -11455,6 +11455,37 @@ export type GetRefTargetByFocusQuery = {
 	refTargets: Array<{ __typename?: 'ref_target'; id: string; description: string }>;
 };
 
+export type GetProfessionalsForStructureQueryVariables = Exact<{
+	structureId: Scalars['uuid'];
+}>;
+
+export type GetProfessionalsForStructureQuery = {
+	__typename?: 'query_root';
+	professional: Array<{
+		__typename?: 'professional';
+		id: string;
+		firstname: string;
+		lastname: string;
+		mobileNumber?: string | null | undefined;
+		email: string;
+		structure: {
+			__typename?: 'structure';
+			id: string;
+			beneficiaries_aggregate: {
+				__typename?: 'beneficiary_structure_aggregate';
+				aggregate?:
+					| { __typename?: 'beneficiary_structure_aggregate_fields'; count: number }
+					| null
+					| undefined;
+			};
+		};
+		account?:
+			| { __typename?: 'account'; onboardingDone?: boolean | null | undefined }
+			| null
+			| undefined;
+	}>;
+};
+
 export type UpdateStructureMutationVariables = Exact<{
 	id: Scalars['uuid'];
 	address1?: InputMaybe<Scalars['String']>;
@@ -19490,6 +19521,115 @@ export const GetRefTargetByFocusDocument = {
 		},
 	],
 } as unknown as DocumentNode<GetRefTargetByFocusQuery, GetRefTargetByFocusQueryVariables>;
+export const GetProfessionalsForStructureDocument = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'OperationDefinition',
+			operation: 'query',
+			name: { kind: 'Name', value: 'GetProfessionalsForStructure' },
+			variableDefinitions: [
+				{
+					kind: 'VariableDefinition',
+					variable: { kind: 'Variable', name: { kind: 'Name', value: 'structureId' } },
+					type: {
+						kind: 'NonNullType',
+						type: { kind: 'NamedType', name: { kind: 'Name', value: 'uuid' } },
+					},
+				},
+			],
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'professional' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'where' },
+								value: {
+									kind: 'ObjectValue',
+									fields: [
+										{
+											kind: 'ObjectField',
+											name: { kind: 'Name', value: 'structureId' },
+											value: {
+												kind: 'ObjectValue',
+												fields: [
+													{
+														kind: 'ObjectField',
+														name: { kind: 'Name', value: '_eq' },
+														value: {
+															kind: 'Variable',
+															name: { kind: 'Name', value: 'structureId' },
+														},
+													},
+												],
+											},
+										},
+									],
+								},
+							},
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'firstname' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'lastname' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mobileNumber' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'structure' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'beneficiaries_aggregate' },
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{
+															kind: 'Field',
+															name: { kind: 'Name', value: 'aggregate' },
+															selectionSet: {
+																kind: 'SelectionSet',
+																selections: [
+																	{ kind: 'Field', name: { kind: 'Name', value: 'count' } },
+																],
+															},
+														},
+													],
+												},
+											},
+										],
+									},
+								},
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'account' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'onboardingDone' } },
+										],
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+		},
+	],
+} as unknown as DocumentNode<
+	GetProfessionalsForStructureQuery,
+	GetProfessionalsForStructureQueryVariables
+>;
 export const UpdateStructureDocument = {
 	kind: 'Document',
 	definitions: [
@@ -26882,6 +27022,10 @@ export type AddNotebookTargetMutationStore = OperationStore<
 export type GetRefTargetByFocusQueryStore = OperationStore<
 	GetRefTargetByFocusQuery,
 	GetRefTargetByFocusQueryVariables
+>;
+export type GetProfessionalsForStructureQueryStore = OperationStore<
+	GetProfessionalsForStructureQuery,
+	GetProfessionalsForStructureQueryVariables
 >;
 export type UpdateStructureMutationStore = OperationStore<
 	UpdateStructureMutation,

--- a/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -11468,19 +11468,18 @@ export type GetProfessionalsForStructureQuery = {
 		lastname: string;
 		mobileNumber?: string | null | undefined;
 		email: string;
-		structure: {
-			__typename?: 'structure';
-			id: string;
-			beneficiaries_aggregate: {
-				__typename?: 'beneficiary_structure_aggregate';
-				aggregate?:
-					| { __typename?: 'beneficiary_structure_aggregate_fields'; count: number }
-					| null
-					| undefined;
-			};
-		};
 		account?:
-			| { __typename?: 'account'; onboardingDone?: boolean | null | undefined }
+			| {
+					__typename?: 'account';
+					onboardingDone?: boolean | null | undefined;
+					notebooksWhereMember_aggregate: {
+						__typename?: 'notebook_member_aggregate';
+						aggregate?:
+							| { __typename?: 'notebook_member_aggregate_fields'; count: number }
+							| null
+							| undefined;
+					};
+			  }
 			| null
 			| undefined;
 	}>;
@@ -19582,14 +19581,14 @@ export const GetProfessionalsForStructureDocument = {
 								{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
 								{
 									kind: 'Field',
-									name: { kind: 'Name', value: 'structure' },
+									name: { kind: 'Name', value: 'account' },
 									selectionSet: {
 										kind: 'SelectionSet',
 										selections: [
-											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'onboardingDone' } },
 											{
 												kind: 'Field',
-												name: { kind: 'Name', value: 'beneficiaries_aggregate' },
+												name: { kind: 'Name', value: 'notebooksWhereMember_aggregate' },
 												selectionSet: {
 													kind: 'SelectionSet',
 													selections: [
@@ -19606,16 +19605,6 @@ export const GetProfessionalsForStructureDocument = {
 													],
 												},
 											},
-										],
-									},
-								},
-								{
-									kind: 'Field',
-									name: { kind: 'Name', value: 'account' },
-									selectionSet: {
-										kind: 'SelectionSet',
-										selections: [
-											{ kind: 'Field', name: { kind: 'Name', value: 'onboardingDone' } },
 										],
 									},
 								},

--- a/src/lib/ui/ProfessionalList/Container.svelte
+++ b/src/lib/ui/ProfessionalList/Container.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	// import type { GetProfessionalsFromStructuresQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import { GetProfessionalsForStructureDocument } from '$lib/graphql/_gen/typed-document-nodes';
+
+	import { operationStore, query } from '@urql/svelte';
+	import { LoaderIndicator } from '../utils';
+	import List from './List.svelte';
+
+	export let structureId: string = null;
+
+	const getProfessionals = operationStore(
+		GetProfessionalsForStructureDocument,
+		{ structureId },
+		{ requestPolicy: 'cache-and-network' }
+	);
+
+	query(getProfessionals);
+
+	$: professionals = $getProfessionals.data?.professional ?? [];
+</script>
+
+<div class="flex flex-col gap-8">
+	<LoaderIndicator result={getProfessionals}>
+		<List {professionals} />
+	</LoaderIndicator>
+</div>

--- a/src/lib/ui/ProfessionalList/Container.svelte
+++ b/src/lib/ui/ProfessionalList/Container.svelte
@@ -1,12 +1,36 @@
 <script lang="ts">
-	// import type { GetProfessionalsFromStructuresQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import type { BeneficiaryCountFilter } from './Filters.svelte';
+	import type { GetProfessionalsForStructureQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	type Professional = GetProfessionalsForStructureQuery['professional'][0];
+
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { GetProfessionalsForStructureDocument } from '$lib/graphql/_gen/typed-document-nodes';
 
 	import { operationStore, query } from '@urql/svelte';
 	import { LoaderIndicator } from '../utils';
 	import List from './List.svelte';
+	import BeneficiaryCountFilterView from './Filters.svelte';
 
+	export let filter: BeneficiaryCountFilter;
 	export let structureId: string = null;
+
+	function updateFilters(event: CustomEvent<{ filter: BeneficiaryCountFilter }>) {
+		const urlParams = new URLSearchParams([...$page.url.searchParams.entries()]);
+		urlParams.set('filter', event.detail.filter);
+		goto(`?${urlParams.toString()}`);
+	}
+
+	function applyFilter(professionals: Professional[], filter: BeneficiaryCountFilter) {
+		if (filter === 'all') return professionals;
+		const predicate =
+			filter === 'noBeneficiaries'
+				? (professional: Professional) =>
+						professional.account.notebooksWhereMember_aggregate.aggregate.count === 0
+				: (professional: Professional) =>
+						professional.account.notebooksWhereMember_aggregate.aggregate.count > 0;
+		return professionals.filter(predicate);
+	}
 
 	const getProfessionals = operationStore(
 		GetProfessionalsForStructureDocument,
@@ -16,10 +40,11 @@
 
 	query(getProfessionals);
 
-	$: professionals = $getProfessionals.data?.professional ?? [];
+	$: professionals = applyFilter($getProfessionals.data?.professional ?? [], filter);
 </script>
 
 <div class="flex flex-col gap-8">
+	<BeneficiaryCountFilterView {filter} on:filter-update={updateFilters} />
 	<LoaderIndicator result={getProfessionals}>
 		<List {professionals} />
 	</LoaderIndicator>

--- a/src/lib/ui/ProfessionalList/Filters.svelte
+++ b/src/lib/ui/ProfessionalList/Filters.svelte
@@ -1,0 +1,50 @@
+<script lang="ts" context="module">
+	export type BeneficiaryCountFilter = 'all' | 'noBeneficiaries' | 'withBeneficiaries';
+
+	export function getFilter(filter: string): BeneficiaryCountFilter {
+		switch (filter) {
+			case 'noBeneficiaries':
+			case 'withBeneficiaries':
+			case 'all':
+				return filter;
+			default:
+				return 'all';
+		}
+	}
+</script>
+
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { Select } from '$lib/ui/base';
+
+	export let filter: string;
+
+	const dispatch = createEventDispatcher();
+
+	let filterOptions: { label: string; name: BeneficiaryCountFilter }[] = [
+		{ label: 'Tous', name: 'all' },
+		{ label: 'Avec', name: 'withBeneficiaries' },
+		{ label: 'Sans', name: 'noBeneficiaries' },
+	];
+
+	function onSubmit() {
+		dispatch('filter-update', { filter });
+	}
+
+	function updateFilters(event: CustomEvent<{ selected: BeneficiaryCountFilter }>) {
+		dispatch('filter-update', { filter: event.detail.selected });
+	}
+</script>
+
+<form on:submit|preventDefault={onSubmit}>
+	<div class="flex items-end justify-between">
+		<Select
+			bind:selected={filter}
+			on:select={updateFilters}
+			options={filterOptions}
+			selectLabel="BRSA suivis"
+			classNames="!mb-0"
+			name="filter"
+		/>
+	</div>
+</form>

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { GetProfessionalsForStructureQuery } from '$lib/graphql/_gen/typed-document-nodes';
+	import { displayFullName } from '../format';
+	type Professional = GetProfessionalsForStructureQuery['professional'][0];
+
+	export let professionals: Professional[];
+</script>
+
+<table class="w-full fr-table fr-table--layout-fixed">
+	<caption class="sr-only">Liste des professionels</caption>
+	<thead>
+		<tr>
+			<th class="text-left">Prénom nom</th>
+			<th class="text-left">Téléphone</th>
+			<th class="text-left">Email</th>
+			<th class="text-left">Onboarding</th>
+			<th class="text-right">BRSA suivis</th>
+		</tr>
+	</thead>
+	<tbody>
+		{#each professionals as professional}
+			<tr>
+				<td>{displayFullName(professional)}</td>
+				<td>{professional.mobileNumber ?? '--'}</td>
+				<td>{professional.email}</td>
+				<td>{professional.account.onboardingDone ? 'Oui' : 'Non'}</td>
+				<td class="flex justify-end">
+					<div
+						class="w-8 h-8 rounded-full flex justify-center items-center bg-information-bg text-information font-bold"
+					>
+						{0}
+					</div>
+				</td>
+			</tr>
+		{/each}
+		{#if professionals.length === 0}
+			<tr><td colspan="10">Aucun professionel.</td></tr>
+		{/if}
+	</tbody>
+</table>

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -4,16 +4,6 @@
 	type Professional = GetProfessionalsForStructureQuery['professional'][0];
 
 	export let professionals: Professional[];
-
-	function beneficiariesCount(professional: Professional) {
-		return professional.account.notebooksWhereMember_aggregate.aggregate.count;
-	}
-
-	function tagClasses(professional: Professional) {
-		const tagColor = beneficiariesCount(professional) === 0 ? 'fr-tag--purple-glycine' : '';
-		// remove the `cursor-default` class when click action is impletemented
-		return `fr-tag fr-tag-sm ${tagColor} cursor-default`;
-	}
 </script>
 
 <table class="w-full fr-table fr-table--layout-fixed">
@@ -29,20 +19,26 @@
 	</thead>
 	<tbody>
 		{#each professionals as professional}
+			{@const beneficiariesCount =
+				professional.account.notebooksWhereMember_aggregate.aggregate.count}
+			{@const hasNoBeneficiaries = beneficiariesCount === 0}
 			<tr>
 				<td>{displayFullName(professional)}</td>
 				<td>{professional.mobileNumber ?? '--'}</td>
 				<td>{professional.email}</td>
 				<td>{professional.account.onboardingDone ? 'Oui' : 'Non'}</td>
 				<td class="flex justify-end">
-					<button class={tagClasses(professional)}>
-						{beneficiariesCount(professional)}
+					<button
+						class="fr-tag fr-tag-sm cursor-default"
+						class:fr-tag--purple-glycine={hasNoBeneficiaries}
+					>
+						{beneficiariesCount}
 					</button>
 				</td>
 			</tr>
 		{/each}
 		{#if professionals.length === 0}
-			<tr><td colspan="10">Aucun professionel.</td></tr>
+			<tr><td colspan="5">Aucun professionel.</td></tr>
 		{/if}
 	</tbody>
 </table>

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -28,7 +28,7 @@
 					<div
 						class="w-8 h-8 rounded-full flex justify-center items-center bg-information-bg text-information font-bold"
 					>
-						{0}
+						{professional.account.notebooksWhereMember_aggregate.aggregate.count}
 					</div>
 				</td>
 			</tr>

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -4,6 +4,16 @@
 	type Professional = GetProfessionalsForStructureQuery['professional'][0];
 
 	export let professionals: Professional[];
+
+	function beneficiariesCount(professional: Professional) {
+		return professional.account.notebooksWhereMember_aggregate.aggregate.count;
+	}
+
+	function tagClasses(professional: Professional) {
+		const tagColor = beneficiariesCount(professional) === 0 ? 'fr-tag--purple-glycine' : '';
+		// remove the `cursor-default` class when click action is impletemented
+		return `fr-tag fr-tag-sm ${tagColor} cursor-default`;
+	}
 </script>
 
 <table class="w-full fr-table fr-table--layout-fixed">
@@ -25,11 +35,9 @@
 				<td>{professional.email}</td>
 				<td>{professional.account.onboardingDone ? 'Oui' : 'Non'}</td>
 				<td class="flex justify-end">
-					<div
-						class="w-8 h-8 rounded-full flex justify-center items-center bg-information-bg text-information font-bold"
-					>
-						{professional.account.notebooksWhereMember_aggregate.aggregate.count}
-					</div>
+					<button class={tagClasses(professional)}>
+						{beneficiariesCount(professional)}
+					</button>
 				</td>
 			</tr>
 		{/each}

--- a/src/lib/ui/ProfessionalList/List.svelte
+++ b/src/lib/ui/ProfessionalList/List.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <table class="w-full fr-table fr-table--layout-fixed">
-	<caption class="sr-only">Liste des professionels</caption>
+	<caption class="sr-only">Liste des professionnels</caption>
 	<thead>
 		<tr>
 			<th class="text-left">Prénom nom</th>

--- a/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
+++ b/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
@@ -5,16 +5,13 @@ query GetProfessionalsForStructure($structureId: uuid!) {
 		lastname
 		mobileNumber
 		email
-    structure {
-      id
-      beneficiaries_aggregate {
+    account {
+      onboardingDone
+      notebooksWhereMember_aggregate {
         aggregate {
           count
         }
       }
-    }
-    account {
-      onboardingDone
     }
 	}
 }

--- a/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
+++ b/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
@@ -1,0 +1,20 @@
+query GetProfessionalsForStructure($structureId: uuid!) {
+	professional(where: { structureId: { _eq: $structureId } }) {
+		id
+		firstname
+		lastname
+		mobileNumber
+		email
+    structure {
+      id
+      beneficiaries_aggregate {
+        aggregate {
+          count
+        }
+      }
+    }
+    account {
+      onboardingDone
+    }
+	}
+}

--- a/src/routes/structures/[uuid]/index.svelte
+++ b/src/routes/structures/[uuid]/index.svelte
@@ -64,6 +64,7 @@
 		{
 			label: pluralize('Professionnel', structure?.professionals_aggregate?.aggregate?.count ?? 0),
 			amount: structure?.professionals_aggregate?.aggregate?.count ?? 0,
+			link: `${structureId}/professionnels`,
 		},
 		{
 			label: `${pluralize('Bénéficiaire', beneficiaries)} ${pluralize(

--- a/src/routes/structures/[uuid]/professionnels.svelte
+++ b/src/routes/structures/[uuid]/professionnels.svelte
@@ -1,0 +1,52 @@
+<script lang="ts" context="module">
+	import type { Load } from '@sveltejs/kit';
+
+	export const load: Load = async ({ params }) => {
+		const structureId = params.uuid;
+		return {
+			props: {
+				structureId,
+			},
+		};
+	};
+</script>
+
+<script lang="ts">
+	import { homeForRole } from '$lib/routes';
+	import Breadcrumbs from '$lib/ui/base/Breadcrumbs.svelte';
+	import { operationStore, query } from '@urql/svelte';
+	import { GetStructureDocument } from '$lib/graphql/_gen/typed-document-nodes';
+	import Container from '$lib/ui/ProfessionalList/Container.svelte';
+
+	export let structureId: string = null;
+
+	const getStructure = operationStore(GetStructureDocument, { structureId });
+	query(getStructure);
+
+	$: structure = $getStructure.data?.structure_by_pk;
+
+	$: breadcrumbs = [
+		{
+			name: 'accueil',
+			path: homeForRole('admin_structure'),
+			label: 'Accueil',
+		},
+		{
+			name: 'structure',
+			path: `${homeForRole('admin_structure')}/${structureId}`,
+			label: `${structure?.name ?? ''}`,
+		},
+		{
+			name: 'professionels',
+			path: '',
+			label: 'Professionnels',
+		},
+	];
+</script>
+
+<svelte:head>
+	<title>Liste des professionels - Carnet de bord</title>
+</svelte:head>
+<Breadcrumbs segments={breadcrumbs} />
+<h1>Professionels</h1>
+<Container {structureId} />

--- a/src/routes/structures/[uuid]/professionnels.svelte
+++ b/src/routes/structures/[uuid]/professionnels.svelte
@@ -1,24 +1,29 @@
 <script lang="ts" context="module">
 	import type { Load } from '@sveltejs/kit';
 
-	export const load: Load = async ({ params }) => {
+	export const load: Load = async ({ params, url }) => {
+		const searchParams = url.searchParams;
 		const structureId = params.uuid;
 		return {
 			props: {
 				structureId,
+				filter: getFilter(searchParams.get('filter')),
 			},
 		};
 	};
 </script>
 
 <script lang="ts">
+	import type { BeneficiaryCountFilter } from '$lib/ui/ProfessionalList/Filters.svelte';
 	import { homeForRole } from '$lib/routes';
 	import Breadcrumbs from '$lib/ui/base/Breadcrumbs.svelte';
+	import { getFilter } from '$lib/ui/ProfessionalList/Filters.svelte';
 	import { operationStore, query } from '@urql/svelte';
 	import { GetStructureDocument } from '$lib/graphql/_gen/typed-document-nodes';
 	import Container from '$lib/ui/ProfessionalList/Container.svelte';
 
 	export let structureId: string = null;
+	export let filter: BeneficiaryCountFilter;
 
 	const getStructure = operationStore(GetStructureDocument, { structureId });
 	query(getStructure);
@@ -49,4 +54,4 @@
 </svelte:head>
 <Breadcrumbs segments={breadcrumbs} />
 <h1>Professionels</h1>
-<Container {structureId} />
+<Container {structureId} {filter} />

--- a/src/routes/structures/[uuid]/professionnels.svelte
+++ b/src/routes/structures/[uuid]/professionnels.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" context="module">
 	import type { Load } from '@sveltejs/kit';
+	import { getFilter } from '$lib/ui/ProfessionalList/Filters.svelte';
 
 	export const load: Load = async ({ params, url }) => {
 		const searchParams = url.searchParams;
@@ -17,7 +18,6 @@
 	import type { BeneficiaryCountFilter } from '$lib/ui/ProfessionalList/Filters.svelte';
 	import { homeForRole } from '$lib/routes';
 	import Breadcrumbs from '$lib/ui/base/Breadcrumbs.svelte';
-	import { getFilter } from '$lib/ui/ProfessionalList/Filters.svelte';
 	import { operationStore, query } from '@urql/svelte';
 	import { GetStructureDocument } from '$lib/graphql/_gen/typed-document-nodes';
 	import Container from '$lib/ui/ProfessionalList/Container.svelte';


### PR DESCRIPTION
closes #902 
## :wrench: Problème

ETQ que gestionnaire de structure, je peux importer des professionnels.
Or, par la suite, je ne peux pas retrouver la liste des professionnels que j'ai importés sur l’outil.
Or l’accès à ces données est essentiel pour que je puisse comprendre / visualiser qui sont les professionnels affectés à la structure dont je suis en charge.

## :cake: Solution

Ajout d'une page présentant la liste des professionnels d'une structure donnée, accessible à tout gestionnaire de structure.


## :rotating_light:  Points d'attention / Remarques

Je n'ai pas utilisé exactement les mêmes couleurs que la maquette mais les couleurs `bg-information` et `text-information`.

## :desert_island: Comment tester

Se rendre sur la review app : https://cdb-app-review-pr1089.osc-fr1.scalingo.io/.
Se connecter en tant que gestionnaire de structure avec le courriel `jacques.celaire@livry-gargan.fr`.
Choisir la structure `Centre Communal d'action social Livry-Gargan`
Cliquer sur la carte `3 Professionnels`
Vérifier que la liste des professionnels de la structure s'affiche.
Celle-ci doit contenir le nom, le prénom, le numéro de téléphone, le courriel, l'information d'onboarding ainsi que le nombre de BRSA suivis pour chaque professionnel.

## 🛎️ Résultat

![Screen Recording 2022-09-16 at 09 39 55](https://user-images.githubusercontent.com/2989532/190653258-a0adea21-aa33-4094-be9c-f0035179e0b5.gif)


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
