### PR TITLE
ci: replace deprecated gha-yarn-cache with setup-node

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Yarn cache setup
-        uses: c-hive/gha-yarn-cache@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
       - name: Install dependencies
         run: |
           yarn install --prefer-offline --frozen-lockfile

--- a/.github/workflows/preproduction.yml
+++ b/.github/workflows/preproduction.yml
@@ -88,8 +88,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Yarn cache setup
-        uses: c-hive/gha-yarn-cache@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
       - name: Install dependencies
         run: |
           yarn --cwd e2e install --prefer-offline --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Yarn cache setup
-        uses: c-hive/gha-yarn-cache@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
+
       - name: Install dependencies
         run: |
           yarn install --prefer-offline --frozen-lockfile
@@ -99,8 +104,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Yarn cache setup
-        uses: c-hive/gha-yarn-cache@v2
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
       - name: Install dependencies
         run: |
           yarn install --prefer-offline --frozen-lockfile


### PR DESCRIPTION
## :wrench: Problème

L'action https://github.com/c-hive/gha-yarn-cache utilisée pour configurer le cache Yarn est obsolète, son `README` recommande d'utiliser désormais l'action standard `actions/setup-node` avec son option `cache`.

Par ailleurs, sans certitude que ce soit lié, on a constaté récemment des instabilités dans l'exécution de cette action : https://github.com/SocialGouv/carnet-de-bord/actions/runs/3081279513/jobs/4979641913, https://github.com/SocialGouv/carnet-de-bord/actions/runs/3081186419/jobs/4979440620, https://github.com/SocialGouv/carnet-de-bord/actions/runs/3081179757/jobs/4979425383, https://github.com/SocialGouv/carnet-de-bord/actions/runs/3064367285/jobs/4947399309 .

De plus, on ne contrôle pas la version de NodeJS utilisée pour la compilation et les tests, étant ainsi dépendant de la version installée sur les images Linux d'exécution de GitHub Actions. Par exemple, lors du passage de Node 18 en LTS les images GitHub devraient basculer rapidement à cette nouvelle version : https://github.com/actions/runner-images/discussions/5429

## :cake: Solution

Comme recommandé par la documentation de `gha-yarn-cache` on met en place `actions/setup-node`. Cette action est configurée pour utiliser le fichier `.nvmrc` déjà présent à la racine du repo.

## :desert_island: Comment tester

Confirmer le fonctionnement des builds CI.