### PR TITLE
ci: Mise à jour automatique de la description d'une Pull Request avec l'adresse de la Review App.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,10 @@
 
 > _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
 
+<!-- BEGIN ## REVIEW APP URL PLACEHOLDER ## -->
+This part will be updated with review app URL [automatically](.github/workflows/review-scalingo.yml).
+<!-- END ## REVIEW APP URL PLACEHOLDER ## -->
+
 
 <!--
 Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,9 +15,9 @@
 
 > _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
 
-<!-- BEGIN ## REVIEW APP URL PLACEHOLDER ## -->
-This part will be updated with review app URL [automatically](.github/workflows/review-scalingo.yml).
-<!-- END ## REVIEW APP URL PLACEHOLDER ## -->
+<!-- BEGIN ## emplacement de l'URL de la review app ## -->
+Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
+<!-- END ## emplacement de l'URL de la review app ## -->
 
 
 <!--

--- a/.github/workflows/review-scalingo.yml
+++ b/.github/workflows/review-scalingo.yml
@@ -31,3 +31,15 @@ jobs:
           SUFFIX: -review-pr${{ github.event.number }}
         run: |
           ./scripts/link-scalingo-apps.sh
+  add-pull-request-comment:
+    name: Add review app URL to Pull Request
+    runs-on: ubuntu-latest
+    needs: [scalingo-link]
+    steps:
+      - name: Add review app URL
+        uses: blablacar/action-sticky-description@master
+        with:
+          issue_number: ${{ github.event.number }}
+          marker: "## REVIEW APP URL PLACEHOLDER ##"
+          message: |
+            Se rendre sur la [review app](https://cdb-app-review-pr${{ github.event.number }}.osc-fr1.scalingo.io).

--- a/.github/workflows/review-scalingo.yml
+++ b/.github/workflows/review-scalingo.yml
@@ -37,7 +37,7 @@ jobs:
     needs: [scalingo-link]
     steps:
       - name: Add review app URL
-        uses: blablacar/action-sticky-description@master
+        uses: blablacar/action-sticky-description@df5650c838f2bbc860ab8edd059b6e255fd7bb82
         with:
           issue_number: ${{ github.event.number }}
           marker: "## REVIEW APP URL PLACEHOLDER ##"

--- a/.github/workflows/review-scalingo.yml
+++ b/.github/workflows/review-scalingo.yml
@@ -40,6 +40,6 @@ jobs:
         uses: blablacar/action-sticky-description@df5650c838f2bbc860ab8edd059b6e255fd7bb82
         with:
           issue_number: ${{ github.event.number }}
-          marker: "## REVIEW APP URL PLACEHOLDER ##"
+          marker: "## emplacement de l'URL de la review app ##"
           message: |
             Se rendre sur la [review app](https://cdb-app-review-pr${{ github.event.number }}.osc-fr1.scalingo.io).


### PR DESCRIPTION
## :wrench: Problème

Chaque ouverture ou ré-ouverture de pull request entraîne la création de review apps sur Scalingo.
Il est possible d'y accéder en cliquant sur le bon _check_ dans la pull request.
Néanmoins, cela est peu pratique car il faut cliquer sur `show all checks`, puis chercher la bonne action et enfin cliquer sur `details` (et dans ce cas, on est redirigé sur la review app dans la même fenêtre, perdant au passage le contexte initial).


## :cake: Solution

On met à jour automatiquement la description de la pull request avec l'adresse de la review app déployée, dans la section _Comment tester_.
Pour cela on utilise [l'action GitHub](https://github.com/blablacar/action-sticky-description) qui permet de remplacer un texte entre 2 balises par le texte de notre choix.
On met également à jour le modèle de pull request pour identifier l'endroit où l'on veut ajouter l'adresse de la review app.


## :rotating_light:  Points d'attention / Remarques

RAS.

## :desert_island: Comment tester

Fermet et ré-ouvrir la pull request pour voir la bonne exécution de l'action.

Le texte ci-après a été mis à jour automatiquement :
<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1100.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->

