### PR TITLE
fix: Ne pas considérer les espaces avant / après lors de la connexion.

### DIFF
--- a/src/routes/auth/login/index.ts
+++ b/src/routes/auth/login/index.ts
@@ -31,7 +31,7 @@ const client = createClient({
 });
 
 const loginSchema = yup.object().shape({
-	username: yup.string().required(),
+	username: yup.string().lowercase().trim().required(),
 });
 type Login = yup.InferType<typeof loginSchema>;
 


### PR DESCRIPTION
fixes #1063

## :wrench: Problème

Lors de la connexion à Carnet de Bord, si l'utilisateur a saisie sans s'en rendre compte (par exemple via un copier / coller) des espaces avant et/ou après son courriel, celui-ci ne sera pas reconnu.
De prime abord, l'utilisateur peut penser que le service est temporairement en panne (cela m'est arrivé ...).

## :cake: Solution

Côté backend, lors de la connexion, on commence par supprimer les espaces avant / après (via la fonction `trim()`).

## :rotating_light:  Points d'attention / Remarques

J'ai tenté de mettre des tests `jest` et `testing-library` mais sans succès :(
A voir la direction que l'on souhaite prendre côté frontend et si cela vaut le coup d'investir du temps sur nos tests frontend.

## :desert_island: Comment tester

Se rendre sur la review app : https://cdb-app-review-pr1101.osc-fr1.scalingo.io/.
Essayer de se connecter avec identifiant valide (ex. `manager.cd93`) **sans espace**.
Vérifier que l'on arrive à se connecter.

Faire le même test en ajoutant des espaces avant l'identifiant (ex. `  manager.cd93`).
Vérifier que l'on arrive à se connecter.

Faire le même test en ajoutant des espaces après l'identifiant (ex. `manager.cd93   `).
Vérifier que l'on arrive à se connecter.

Faire le même test en ajoutant des espaces avant et après l'identifiant (ex. `  manager.cd93  `).
Vérifier que l'on arrive à se connecter.

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
