### PR TITLE
Import Pôle Emploi : ne plus essayer de déchiffrer le fichier `actions`

### DIFF
--- a/backend/scripts/pe-fetch.sh
+++ b/backend/scripts/pe-fetch.sh
@@ -14,13 +14,17 @@ chmod 600 *.pem
 
 echo "download files."
 sftp -o "StrictHostKeyChecking accept-new"  -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE/principal .
-sftp -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE/actions .
+
+# Processing of the "actions" file is disabled for now because it is too large to be decrypted
+# by "openssl smime". See https://marc.info/?l=openssl-users&m=138545785012939
+
+# sftp -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE/actions .
 
 openssl smime -decrypt -in principal -binary -inform DEM -inkey pe_file.pem -out principal.csv
-openssl smime -decrypt -in actions -binary -inform DEM -inkey pe_file.pem -out actions.csv
+# openssl smime -decrypt -in actions -binary -inform DEM -inkey pe_file.pem -out actions.csv
 
 echo "fichier principal: $(wc -l principal.csv) lignes"
-echo "fichier actions: $(wc -l actions.csv) lignes"
+# echo "fichier actions: $(wc -l actions.csv) lignes"
 
 cp principal.csv /mnt/pefiles
-cp actions.csv /mnt/pefiles
+# cp actions.csv /mnt/pefiles


### PR DESCRIPTION
## 💥 Problème

Notre job hebdomadaire de téléchargement des fichiers Pôle Emploi échoue lors du déchiffrement du fichier `actions` depuis que la taille de celui-ci a sensiblement augmenté (passant de 1 Go à 2 Go environ) lors de l'ajout de nouveaux départements (pour la première fois dans le fichier vu le 9 septembre 2022).

L'outil `openssl smime` comporte en effet une limitation qui empêche de traiter les fichiers qui approchent les 2 Go. Voir par exemple https://marc.info/?l=openssl-users&m=138545785012939 ou encore https://gist.github.com/gsilos/879c28279761cd8d38301f7a54bed78a .

## :cake: Solution

Comme on n'utilise pas actuellement les données du fichier `actions`, nous désactivons provisoirement le téléchargement et le déchiffrement de ce fichier, en attendant d'obtenir la livraison d'un fichier exploitable.

## :desert_island: Comment tester

Relancer et surveiller l'import en préproduction ?

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1103.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->