### PR TITLE
feat: add created_at / updated_at on wantedjob

### DIFF
--- a/hasura/migrations/carnet_de_bord/1663750758041_squashed/down.sql
+++ b/hasura/migrations/carnet_de_bord/1663750758041_squashed/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."wanted_job" drop column "updated_at";
+
+alter table "public"."wanted_job" drop column "created_at";

--- a/hasura/migrations/carnet_de_bord/1663750758041_squashed/up.sql
+++ b/hasura/migrations/carnet_de_bord/1663750758041_squashed/up.sql
@@ -1,0 +1,23 @@
+
+alter table "public"."wanted_job" add column "created_at" timestamptz
+ null default now();
+
+alter table "public"."wanted_job" add column "updated_at" timestamptz
+ null default now();
+
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_wanted_job_updated_at"
+BEFORE UPDATE ON "public"."wanted_job"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_wanted_job_updated_at" ON "public"."wanted_job"
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';


### PR DESCRIPTION
## :wrench: Problème

La table wanted_job ne possède pas de colonne created_at / updated_at

## :cake: Solution

Ajouter les colonnes à la table


## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester

Récupérer la branche, et redémarrer hasura. lancer la console Hasura et vérifier que les colonnes existent. 

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1106.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
