### PR TITLE
fix: use same wording on onboarding

### DIFF
--- a/src/routes/manager/professionnels/index.svelte
+++ b/src/routes/manager/professionnels/index.svelte
@@ -146,7 +146,7 @@
 						</td>
 
 						<td>
-							<Text value={account.onboardingDone ? 'Fait' : 'Pas fait'} />
+							<Text value={account.onboardingDone ? 'Fait' : 'Non fait'} />
 						</td>
 						<td class="text-right">
 							<a


### PR DESCRIPTION
## :wrench: Problème

Dans l'affichage de la liste des pros, on affiche dans la colonne onbarding les valeurs "Fait" / "Non fait" ou "Fait" / "Pas fait"

## :cake: Solution

On choisi d'utiliser "Non fait"


## :rotating_light:  Points d'attention / Remarques

ras

## :desert_island: Comment tester

ouvrir les listes de pro dans les 2 profils (manager et admin_structure)

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1107.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
