### PR TITLE
chore: use hasura 2.12-ce image

### DIFF
--- a/.github/actions/hasura-cli/action.yml
+++ b/.github/actions/hasura-cli/action.yml
@@ -1,9 +1,9 @@
-name: 'Setup Hasura CLI'
-description: 'Installs the Hasura CLI'
+name: "Setup Hasura CLI"
+description: "Installs the Hasura CLI"
 inputs:
   hasura-version:
     required: true
-    description: 'Hasura version (e.g. 2.8.3)'
+    description: "Hasura version"
 
 runs:
   using: "composite"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_VERSION}}
-          cache: "poetry"
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: push
 
+env:
+  PYTHON_VERSION: 3.10
+
 concurrency:
   cancel-in-progress: true
   group: lint-${{ github.ref }}
@@ -19,13 +22,13 @@ jobs:
       - name: Setup python for pre-commit
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ PYTHON_VERSION }}
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: yarn
-          cache-dependency-path: 'app/yarn.lock'
+          cache-dependency-path: "app/yarn.lock"
       - name: Install dependencies
         working-directory: app
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup python for pre-commit
         uses: actions/setup-python@v4
         with:
-          python-version: "$PYTHON_VERSION"
+          python-version: ${{env.PYTHON_VERSION}}
           cache: "poetry"
 
       - name: Setup NodeJS

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: push
 
 env:
-  PYTHON_VERSION: 3.10
+  PYTHON_VERSION: 3.10.6
 
 concurrency:
   cancel-in-progress: true
@@ -22,7 +22,9 @@ jobs:
       - name: Setup python for pre-commit
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: "$PYTHON_VERSION"
+          cache: "poetry"
+
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup python for pre-commit
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ PYTHON_VERSION }}
+          python-version: $PYTHON_VERSION
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 env:
   HASURA_VERSION: 2.12.0
   POETRY_VERSION: 1.1.13
-  PYTHON_VERSION: 3.10
+  PYTHON_VERSION: 3.10.6
 
 concurrency:
   cancel-in-progress: true
@@ -34,7 +34,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: "$PYTHON_VERSION"
+          cache: "poetry"
+
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
@@ -79,10 +81,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: $PYTHON_VERSION
+          cache: "poetry"
+
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
           poetry-version: $POETRY_VERSION
+
       - name: Install Python dependencies
         working-directory: ./backend
         run: poetry install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,16 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: ${{ HASURA_VERSION }}
+          hasura-version: $HASURA_VERSION
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ PYTHON_VERSION }}
+          python-version: $PYTHON_VERSION
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: ${{ POETRY_VERSION }}
+          poetry-version: $POETRY_VERSION
       - name: Install dependencies
         working-directory: ./backend
         run: poetry install
@@ -73,16 +73,16 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: ${{ HASURA_VERSION }}
+          hasura-version: $HASURA_VERSION
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ PYTHON_VERSION }}
+          python-version: $PYTHON_VERSION
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: ${{ POETRY_VERSION }}
+          poetry-version: $POETRY_VERSION
       - name: Install Python dependencies
         working-directory: ./backend
         run: poetry install
@@ -124,7 +124,7 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: ${{ HASURA_VERSION }}
+          hasura-version: $HASURA_VERSION
 
       - name: Run functional tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,13 @@ name: Test
 on:
   push:
     branches-ignore:
-      - 'master'
+      - "master"
     tags-ignore:
       - v*
+env:
+  HASURA_VERSION: 2.12.0
+  POETRY_VERSION: 1.1.13
+  PYTHON_VERSION: 3.10
 
 concurrency:
   cancel-in-progress: true
@@ -25,16 +29,16 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: 2.8.3
+          hasura-version: ${{ HASURA_VERSION }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ PYTHON_VERSION }}
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: 1.1.13
+          poetry-version: ${{ POETRY_VERSION }}
       - name: Install dependencies
         working-directory: ./backend
         run: poetry install
@@ -57,9 +61,9 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: yarn
-          cache-dependency-path: '**/yarn.lock'
+          cache-dependency-path: "**/yarn.lock"
 
       - name: Install dependencies
         run: |
@@ -69,16 +73,16 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: 2.8.3
+          hasura-version: ${{ HASURA_VERSION }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ PYTHON_VERSION }}
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: 1.1.13
+          poetry-version: ${{ POETRY_VERSION }}
       - name: Install Python dependencies
         working-directory: ./backend
         run: poetry install
@@ -108,9 +112,9 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: yarn
-          cache-dependency-path: 'app/yarn.lock'
+          cache-dependency-path: "app/yarn.lock"
 
       - name: Install dependencies
         run: |
@@ -120,7 +124,7 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: 2.8.3
+          hasura-version: ${{ HASURA_VERSION }}
 
       - name: Run functional tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,18 +29,18 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: "$HASURA_VERSION"
+          hasura-version: ${{env.HASURA_VERSION}}
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "$PYTHON_VERSION"
+          python-version: ${{env.PYTHON_VERSION}}
           cache: "poetry"
 
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: "$POETRY_VERSION"
+          poetry-version: ${{env.POETRY_VERSION}}
 
       - name: Install dependencies
         working-directory: ./backend
@@ -76,18 +76,18 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: "$HASURA_VERSION"
+          hasura-version: ${{env.HASURA_VERSION}}
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "$PYTHON_VERSION"
+          python-version: ${{env.PYTHON_VERSION}}
           cache: "poetry"
 
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: "$POETRY_VERSION"
+          poetry-version: ${{env.POETRY_VERSION}}
 
       - name: Install Python dependencies
         working-directory: ./backend
@@ -130,7 +130,7 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: "$HASURA_VERSION"
+          hasura-version: ${{env.HASURA_VERSION}}
 
       - name: Run functional tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: $HASURA_VERSION
+          hasura-version: "$HASURA_VERSION"
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -40,7 +40,8 @@ jobs:
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: $POETRY_VERSION
+          poetry-version: "$POETRY_VERSION"
+
       - name: Install dependencies
         working-directory: ./backend
         run: poetry install
@@ -75,18 +76,18 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: $HASURA_VERSION
+          hasura-version: "$HASURA_VERSION"
 
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: "$PYTHON_VERSION"
           cache: "poetry"
 
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
         with:
-          poetry-version: $POETRY_VERSION
+          poetry-version: "$POETRY_VERSION"
 
       - name: Install Python dependencies
         working-directory: ./backend
@@ -129,7 +130,7 @@ jobs:
       - name: Install Hasura CLI
         uses: ./.github/actions/hasura-cli
         with:
-          hasura-version: $HASURA_VERSION
+          hasura-version: "$HASURA_VERSION"
 
       - name: Run functional tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_VERSION}}
-          cache: "poetry"
 
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5
@@ -82,7 +81,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{env.PYTHON_VERSION}}
-          cache: "poetry"
 
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.5

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,9 +7,9 @@ Vous devez au préalable avoir correctement installé les logiciels suivants :
 - docker (version 20.10.5)
 - docker-compose (version 1.29.0)
 - node (version 16)
-- hasura-cli (version 2.0.2)
+- hasura-cli (latest)
 - pre-commit https://pre-commit.com
-- poetry (1.1.14)
+- poetry (1.1.13)
 
 > ℹ️️ Les versions indiquées sont celles utilisées et préconisées par l'équipe de développement. Il est possible que l'application fonctionne avec des versions différentes.
 

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.8.3.cli-migrations-v3
+FROM hasura/graphql-engine:v2.12.0-ce.cli-migrations-v3
 
 ENV HASURA_GRAPHQL_ENABLE_TELEMETRY=false
 ENV HASURA_GRAPHQL_SHOW_UPDATE_NOTIFICATION=false


### PR DESCRIPTION
## :wrench: Problème

L'image docker d'hasura utilisé actuellement contient à la fois les composant open source et closed source et est en retard de version. 
Depuis la version 2.12, Hasura met à disposition une image avec seulement les composants opensource. Cela permettrait d'alléger l'image finale. Afin de pouvoir bénéficier des dernieres fonctionnalité ainsi que les corrections de bug,  on souhaite avoir des mises à jour régulière.

## :cake: Solution

mettre à jour le nom de l'image utilisée avec le prefix `-ce`  



## :desert_island: Comment tester

Si tests e2e passent on peut être confiant dans le bon fonctionnement de l'appli

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1113.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
