### PR TITLE
fix: case insensitive search for structure names

### DIFF
--- a/backend/api/db/crud/structure.py
+++ b/backend/api/db/crud/structure.py
@@ -34,7 +34,7 @@ async def get_structure_by_name(connection: Connection, name: str) -> Structure 
     return await get_structure_with_query(
         connection,
         """
-        WHERE name=$1
+        WHERE trim(lower(name))=trim(lower($1))
         """,
         name,
     )

--- a/backend/tests/test_structure.py
+++ b/backend/tests/test_structure.py
@@ -31,3 +31,12 @@ async def test_get_structure_by_name(db_connection):
     )
 
     assert structure is not None
+
+
+async def test_get_structure_by_name_case_insensitive(db_connection):
+
+    structure: Structure | None = await get_structure_by_name(
+        db_connection, "pole emploi agence livry-gargnan"
+    )
+
+    assert structure is not None


### PR DESCRIPTION
## :wrench: Problème

Lors de la recherche d'une structure par nom, on considère que deux structures qui ont le même nom mais avec une casse différente sont les mêmes.

## :cake: Solution

Lors de la recherche d'une structure, on passe en minuscules le nom recherché.


## :rotating_light:  Points d'attention / Remarques

On en profite pour trimmer les noms existants en plus du fait de les passer en minuscule, parce que pourquoi pas ?

## :desert_island: Comment tester

Non applicable (le test unitaire ajouté couvre le cas)

fix #1098 