### PR TITLE
Mise à jour du texte de bienvenue de la page d'accueil.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Carnet de bord
 
-[Carnet de bord](https://carnet-de-bord.fabrique.social.gouv.fr/) est un service public dont l'objectif est de faciliter la coordination des échanges entres acteurs et simplifier la lecture des parcours d’insertion.
+[Carnet de bord](https://carnet-de-bord.fabrique.social.gouv.fr/) est un service public dont l'objectif est de faciliter la coordination des échanges entre acteurs et simplifier la lecture des parcours d’insertion.
 
 ![Page d'accueil du site Carnet de bord](./docs/screenshot_cdb_20220819.png)
 

--- a/app/src/routes/index.svelte
+++ b/app/src/routes/index.svelte
@@ -38,7 +38,7 @@
 			Beta.Gouv, le Carnet de bord est un service public numérique qui a pour objectif de <strong
 				>faciliter</strong
 			>
-			la coordination des échanges entres acteurs et de <strong>simplifier</strong> la lecture des parcours
+			la coordination des échanges entre acteurs et de <strong>simplifier</strong> la lecture des parcours
 			d’insertion. Il permet :
 		</p>
 		<ul>

--- a/app/src/routes/index.svelte
+++ b/app/src/routes/index.svelte
@@ -21,7 +21,7 @@
 			<img alt="" aria-hidden="true" src="/images/cdb-landing-illustration-intro.svg" />
 		</div>
 		<div class="w-8/12">
-			<h1>La nouvelle version du Carnet de bord est en ligne !</h1>
+			<h1>Bienvenue sur Carnet de bord !</h1>
 			<p>
 				Partager le parcours pour faciliter les avancées des personnes en insertion et de leurs
 				accompagnateurs.

--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -9,5 +9,5 @@ Fonctionnalité: Page d'accueil
 
 Scénario: Home CdB
 	Soit un utilisateur sur la page d'accueil
-	Alors je vois "La nouvelle version du Carnet de bord est en ligne"
+	Alors je vois "Bienvenue sur Carnet de bord !"
 	Alors le lien "Accéder à mon compte" pointe sur "/auth/login"


### PR DESCRIPTION
closes #1112

## :wrench: Problème

Actuellement, la page d'accueil affiche un texte de bienvenue faisant mention d'une nouvelle version en ligne (sic).
Une nouvelle version étant effectivement prévue et parfois mentionnée aux différents acteurs du produit, cela porte à confusion.

## :cake: Solution

Remplacer *"La nouvelle version du Carnet de bord est en ligne !"* par *Bienvenue sur Carnet de bord !*.
On en profite également pour corriger la typo (le `s` en trop à `entre`) dans la page d'acceuil.


## :rotating_light:  Points d'attention / Remarques

La même typo existait également dans le `README`, on en profite pour corriger cette faute également.

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1123.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

Vérifier que le texte affiché est *Bienvenue sur Carnet de bord !*.
<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
