### PR TITLE
fix: use correct logging level

### DIFF
--- a/backend/cdb_csv/pe.py
+++ b/backend/cdb_csv/pe.py
@@ -180,7 +180,7 @@ async def import_beneficiaries(connection: Connection, principal_csv: str):
                         )
                     )
             else:
-                logging.error(
+                logging.info(
                     "{} - No new beneficiary to import. Skipping.".format(
                         row["identifiant_unique_de"]
                     )


### PR DESCRIPTION
## :wrench: Problème

Dans sentry, de simples messages d'information remontent comme des erreurs.

## :cake: Solution

Corriger le niveau d'erreur du log