### PR TITLE
feat: Ajout du numéro de version dans le pied de page de l'application.

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -18,4 +18,7 @@ module.exports = {
 	rules: {
 		'no-unused-vars': 'off',
 	},
+	globals: {
+		__version__: 'readonly',
+	},
 };

--- a/app/src/global.d.ts
+++ b/app/src/global.d.ts
@@ -34,3 +34,5 @@ declare namespace App {
 		backendAPI?: string;
 	}
 }
+
+declare const __version__: string;

--- a/app/src/lib/ui/base/Footer.svelte
+++ b/app/src/lib/ui/base/Footer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Link } from '$lib/ui/base';
 	export let landing: string | null = '/';
+	const appVersion = __version__;
 </script>
 
 <footer class="fr-footer mt-8" id="footer">
@@ -36,6 +37,15 @@
 		</div>
 		<div class="fr-footer__bottom">
 			<ul class="fr-footer__bottom-list">
+				<li class="fr-footer__bottom-item">
+					<a
+						class="fr-footer__bottom-link"
+						href="https://github.com/SocialGouv/carnet-de-bord/blob/master/CHANGELOG.md"
+						target="_blank"
+					>
+						Version {appVersion}
+					</a>
+				</li>
 				<li class="fr-footer__bottom-item">
 					<!-- svelte-ignore a11y-missing-attribute -->
 					<a class="fr-footer__bottom-link">Plan du site</a>

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -36,6 +36,9 @@ const config = {
 					external: [/\.test\.(t|j)s$/],
 				},
 			},
+			define: {
+				__version__: JSON.stringify(process.env.npm_package_version),
+			},
 		},
 		adapter: adapter({
 			// default options are shown


### PR DESCRIPTION
## :wrench: Problème

Il est compliqué aujourd'hui pour un utilisateur lambda de connaitre la version de l'application client actuellement utilisée.
Cela est pourtant une donnée clé pour comprendre / analyser les rapports de bogues ou demandes d'évolutions.

## :cake: Solution

On ajoute la version dans le pied de page de l'application client.
Celle-ci est lue depuis le fichier `package.json` afin de garantir sa cohérence.
On en profite pour faire de ce numéro de version un lien vers le fichier `CHANGELOG.md` permettant aux utilisateurs curieux de s'informer des changements.


## :rotating_light:  Points d'attention / Remarques

Voir la documentation de [Vite](https://vitejs.dev/config/shared-options.html#define) pour comprendre comment rendre disponible une variable globale.

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Se rendre sur la [review app](https://cdb-app-review-pr1135.osc-fr1.scalingo.io/).
<!-- END ## emplacement de l'URL de la review app ## -->

Vérifier que le pied de page contient un texte de la forme `Version x.y.z`.
Cliquer sur ce texte.
Vérifier qu'un nouvel onglet est ouvert et que celui-ci affiche le Changelog.

## 🛎️  Résultat

![Screen Recording 2022-09-28 at 18 37 40](https://user-images.githubusercontent.com/2989532/192901056-cb244817-251e-48e5-b40c-dfe7e12bf6a9.gif)

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
