### PR TITLE
fix: catch des exceptions lancées à chaque parsing de ligne CSV

### DIFF
--- a/backend/cdb_csv/pe.py
+++ b/backend/cdb_csv/pe.py
@@ -198,7 +198,7 @@ async def import_beneficiaries(connection: Connection, principal_csv: str):
                 )
 
         except Exception as e:
-            logging.error("Exception while parsing CSV line: {}".format(e))
+            logging.error("Exception while processing CSV line: {}".format(e))
             traceback.print_exc()
 
 

--- a/backend/cdb_csv/pe.py
+++ b/backend/cdb_csv/pe.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import uuid
 from uuid import UUID
 
@@ -131,13 +132,13 @@ async def match_beneficiaries_and_pros(connection: Connection, principal_csv: st
 
 async def import_beneficiaries(connection: Connection, principal_csv: str):
 
-    try:
-        df = dd.read_csv(
-            principal_csv, sep=";", dtype=str, keep_default_na=False, na_values=["_"]
-        )
+    df = dd.read_csv(
+        principal_csv, sep=";", dtype=str, keep_default_na=False, na_values=["_"]
+    )
 
-        row: Series
-        for _, row in df.iterrows():
+    row: Series
+    for _, row in df.iterrows():
+        try:
 
             logging.info(
                 "{id} => Trying to import main row {id}".format(
@@ -196,8 +197,9 @@ async def import_beneficiaries(connection: Connection, principal_csv: str):
                     )
                 )
 
-    except Exception as e:
-        logging.error("Exception while parsing CSV line: {}".format(e))
+        except Exception as e:
+            logging.error("Exception while parsing CSV line: {}".format(e))
+            traceback.print_exc()
 
 
 async def import_pe_referent(

--- a/backend/tests/test_pe_csv_import.py
+++ b/backend/tests/test_pe_csv_import.py
@@ -201,4 +201,4 @@ async def test_parse_principal_csv_exception(
     with caplog.at_level(logging.ERROR):
         await import_beneficiaries(db_connection, pe_principal_csv_filepath)
 
-        assert "Exception while parsing CSV line: Parsing exception" in caplog.text
+        assert "Exception while processing CSV line: Parsing exception" in caplog.text

--- a/backend/tests/test_pe_csv_import.py
+++ b/backend/tests/test_pe_csv_import.py
@@ -1,7 +1,9 @@
 import logging
+from unittest.mock import patch
 from uuid import UUID
 
 import httpx
+import pytest
 import respx
 from asyncpg.connection import Connection
 
@@ -183,3 +185,17 @@ async def test_insert_wanted_jobs_for_csv_row_and_notebook(
 
         assert sophie_tifour is not None and sophie_tifour.notebook is not None
         assert len(sophie_tifour.notebook.wanted_jobs) == 3
+
+
+async def test_parse_principal_csv_exception(
+    pe_principal_csv_filepath: str, db_connection: Connection, caplog
+):
+    with patch(
+        "cdb_csv.pe.map_principal_row", side_effect=Exception("Parsing exception")
+    ):
+        await import_beneficiaries(db_connection, pe_principal_csv_filepath)
+
+        with caplog.at_level(logging.ERROR):
+            await import_beneficiaries(db_connection, pe_principal_csv_filepath)
+
+            assert "Exception while parsing CSV line" in caplog.text


### PR DESCRIPTION
## :wrench: Problème

Lorsqu'une exception est lancée dans le code d'import PE pour une ligne donnée le script plante et les autres lignes ne sont pas traitées.

## :cake: Solution

Capturer les exceptions lancées lors de l'analyse de chaque ligne du CSV.

## :rotating_light:  Points d'attention / Remarques

Toutes les exceptions sont capturées avec un _catch all_

## :desert_island: Comment tester

Difficile à tester en dehors de la production.
Lors du prochain import pôle emploi, s'assurer que toutes les lignes ont bien été traitées.

fix #1128 