### PR TITLE
feat(backend):  import structures endpoint

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -63,7 +63,7 @@ export type InsertStructureWithAdminOutput = {
 	city?: Maybe<Scalars['String']>;
 	email?: Maybe<Scalars['citext']>;
 	id: Scalars['uuid'];
-	name?: Maybe<Scalars['String']>;
+	name?: Maybe<Scalars['citext']>;
 	phone?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	shortDesc?: Maybe<Scalars['String']>;
@@ -109,7 +109,7 @@ export type StructureInput = {
 	address2?: InputMaybe<Scalars['String']>;
 	city?: InputMaybe<Scalars['String']>;
 	email?: InputMaybe<Scalars['String']>;
-	name?: InputMaybe<Scalars['String']>;
+	name: Scalars['citext'];
 	phone?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	shortDesc?: InputMaybe<Scalars['String']>;
@@ -10107,7 +10107,7 @@ export type Structure = {
 	deploymentId?: Maybe<Scalars['uuid']>;
 	email?: Maybe<Scalars['String']>;
 	id: Scalars['uuid'];
-	name?: Maybe<Scalars['String']>;
+	name: Scalars['citext'];
 	phone?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	/** An array relationship */
@@ -10224,7 +10224,7 @@ export type StructureBoolExp = {
 	deploymentId?: InputMaybe<UuidComparisonExp>;
 	email?: InputMaybe<StringComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
-	name?: InputMaybe<StringComparisonExp>;
+	name?: InputMaybe<CitextComparisonExp>;
 	phone?: InputMaybe<StringComparisonExp>;
 	postalCode?: InputMaybe<StringComparisonExp>;
 	professionals?: InputMaybe<ProfessionalBoolExp>;
@@ -10254,7 +10254,7 @@ export type StructureInsertInput = {
 	deploymentId?: InputMaybe<Scalars['uuid']>;
 	email?: InputMaybe<Scalars['String']>;
 	id?: InputMaybe<Scalars['uuid']>;
-	name?: InputMaybe<Scalars['String']>;
+	name?: InputMaybe<Scalars['citext']>;
 	phone?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	professionals?: InputMaybe<ProfessionalArrRelInsertInput>;
@@ -10274,7 +10274,7 @@ export type StructureMaxFields = {
 	deploymentId?: Maybe<Scalars['uuid']>;
 	email?: Maybe<Scalars['String']>;
 	id?: Maybe<Scalars['uuid']>;
-	name?: Maybe<Scalars['String']>;
+	name?: Maybe<Scalars['citext']>;
 	phone?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	shortDesc?: Maybe<Scalars['String']>;
@@ -10311,7 +10311,7 @@ export type StructureMinFields = {
 	deploymentId?: Maybe<Scalars['uuid']>;
 	email?: Maybe<Scalars['String']>;
 	id?: Maybe<Scalars['uuid']>;
-	name?: Maybe<Scalars['String']>;
+	name?: Maybe<Scalars['citext']>;
 	phone?: Maybe<Scalars['String']>;
 	postalCode?: Maybe<Scalars['String']>;
 	shortDesc?: Maybe<Scalars['String']>;
@@ -10429,7 +10429,7 @@ export type StructureSetInput = {
 	deploymentId?: InputMaybe<Scalars['uuid']>;
 	email?: InputMaybe<Scalars['String']>;
 	id?: InputMaybe<Scalars['uuid']>;
-	name?: InputMaybe<Scalars['String']>;
+	name?: InputMaybe<Scalars['citext']>;
 	phone?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	shortDesc?: InputMaybe<Scalars['String']>;
@@ -10455,7 +10455,7 @@ export type StructureStreamCursorValueInput = {
 	deploymentId?: InputMaybe<Scalars['uuid']>;
 	email?: InputMaybe<Scalars['String']>;
 	id?: InputMaybe<Scalars['uuid']>;
-	name?: InputMaybe<Scalars['String']>;
+	name?: InputMaybe<Scalars['citext']>;
 	phone?: InputMaybe<Scalars['String']>;
 	postalCode?: InputMaybe<Scalars['String']>;
 	shortDesc?: InputMaybe<Scalars['String']>;
@@ -12013,7 +12013,7 @@ export type GetBeneficiariesQuery = {
 			| undefined;
 		structures: Array<{
 			__typename?: 'beneficiary_structure';
-			structure: { __typename?: 'structure'; id: string; name?: string | null | undefined };
+			structure: { __typename?: 'structure'; id: string; name: string };
 		}>;
 		notebook?:
 			| {
@@ -12083,7 +12083,7 @@ export type GetProfessionalsForManagerQuery = {
 		email: string;
 		structureId: string;
 		account?: { __typename?: 'account'; id: string } | null | undefined;
-		structure: { __typename?: 'structure'; id: string; name?: string | null | undefined };
+		structure: { __typename?: 'structure'; id: string; name: string };
 	}>;
 };
 
@@ -12103,7 +12103,7 @@ export type GetProfessionalsFromStructuresQuery = {
 		email: string;
 		structureId: string;
 		account?: { __typename?: 'account'; id: string } | null | undefined;
-		structure: { __typename?: 'structure'; id: string; name?: string | null | undefined };
+		structure: { __typename?: 'structure'; id: string; name: string };
 	}>;
 };
 
@@ -12111,7 +12111,7 @@ export type GetStructuresForManagerQueryVariables = Exact<{ [key: string]: never
 
 export type GetStructuresForManagerQuery = {
 	__typename?: 'query_root';
-	structure: Array<{ __typename?: 'structure'; id: string; name?: string | null | undefined }>;
+	structure: Array<{ __typename?: 'structure'; id: string; name: string }>;
 };
 
 export type GetStructuresWithProQueryVariables = Exact<{ [key: string]: never }>;
@@ -12121,7 +12121,7 @@ export type GetStructuresWithProQuery = {
 	structure: Array<{
 		__typename?: 'structure';
 		id: string;
-		name?: string | null | undefined;
+		name: string;
 		professionals: Array<{
 			__typename?: 'professional';
 			id: string;
@@ -12132,7 +12132,7 @@ export type GetStructuresWithProQuery = {
 			email: string;
 			structureId: string;
 			account?: { __typename?: 'account'; id: string } | null | undefined;
-			structure: { __typename?: 'structure'; id: string; name?: string | null | undefined };
+			structure: { __typename?: 'structure'; id: string; name: string };
 		}>;
 	}>;
 };
@@ -12405,7 +12405,7 @@ export type ImportBeneficiaryMutation = {
 };
 
 export type ImportStructureMutationVariables = Exact<{
-	name?: InputMaybe<Scalars['String']>;
+	name: Scalars['citext'];
 	phone?: InputMaybe<Scalars['String']>;
 	email?: InputMaybe<Scalars['String']>;
 	address1?: InputMaybe<Scalars['String']>;
@@ -12600,7 +12600,7 @@ export type GetNotebookFocusByIdQuery = {
 								structure: {
 									__typename?: 'structure';
 									id: string;
-									name?: string | null | undefined;
+									name: string;
 									phone?: string | null | undefined;
 									address1?: string | null | undefined;
 									address2?: string | null | undefined;
@@ -12666,6 +12666,7 @@ export type UpdateTargetStatusMutation = {
 
 export type SearchProfessionalQueryVariables = Exact<{
 	search?: InputMaybe<Scalars['String']>;
+	searchStructure?: InputMaybe<Scalars['citext']>;
 	accountIds?: InputMaybe<Array<Scalars['uuid']> | Scalars['uuid']>;
 }>;
 
@@ -12679,7 +12680,7 @@ export type SearchProfessionalQuery = {
 		structure: {
 			__typename?: 'structure';
 			id: string;
-			name?: string | null | undefined;
+			name: string;
 			postalCode?: string | null | undefined;
 			phone?: string | null | undefined;
 		};
@@ -12884,7 +12885,7 @@ export type UpdateStructureMutationVariables = Exact<{
 	shortDesc?: InputMaybe<Scalars['String']>;
 	siret?: InputMaybe<Scalars['String']>;
 	phone?: InputMaybe<Scalars['String']>;
-	name?: InputMaybe<Scalars['String']>;
+	name?: InputMaybe<Scalars['citext']>;
 	email?: InputMaybe<Scalars['String']>;
 }>;
 
@@ -12941,7 +12942,7 @@ export type GetAccountByPkQuery = {
 							structure: {
 								__typename?: 'structure';
 								id: string;
-								name?: string | null | undefined;
+								name: string;
 								address1?: string | null | undefined;
 								address2?: string | null | undefined;
 								postalCode?: string | null | undefined;
@@ -13141,7 +13142,7 @@ export type InsertAccountAdminStructureMutation = {
 };
 
 export type InsertStructureMutationVariables = Exact<{
-	name?: InputMaybe<Scalars['String']>;
+	name: Scalars['citext'];
 	phone?: InputMaybe<Scalars['String']>;
 	email?: InputMaybe<Scalars['String']>;
 	address1?: InputMaybe<Scalars['String']>;
@@ -13210,7 +13211,7 @@ export type GetStructuresForDeploymentQuery = {
 		__typename?: 'structure';
 		id: string;
 		siret?: string | null | undefined;
-		name?: string | null | undefined;
+		name: string;
 		shortDesc?: string | null | undefined;
 		phone?: string | null | undefined;
 		email?: string | null | undefined;
@@ -13491,7 +13492,7 @@ export type GetNotebookByBeneficiaryIdQuery = {
 							structure: {
 								__typename?: 'structure';
 								id: string;
-								name?: string | null | undefined;
+								name: string;
 								address1?: string | null | undefined;
 								address2?: string | null | undefined;
 								postalCode?: string | null | undefined;
@@ -13521,7 +13522,7 @@ export type GetNotebookByBeneficiaryIdQuery = {
 							__typename?: 'professional';
 							firstname: string;
 							lastname: string;
-							structure: { __typename?: 'structure'; name?: string | null | undefined };
+							structure: { __typename?: 'structure'; name: string };
 					  }
 					| null
 					| undefined;
@@ -13545,7 +13546,7 @@ export type GetNotebookByBeneficiaryIdQuery = {
 								__typename?: 'professional';
 								firstname: string;
 								lastname: string;
-								structure: { __typename?: 'structure'; name?: string | null | undefined };
+								structure: { __typename?: 'structure'; name: string };
 						  }
 						| null
 						| undefined;
@@ -13570,7 +13571,7 @@ export type GetNotebookByBeneficiaryIdQuery = {
 									__typename?: 'professional';
 									firstname: string;
 									lastname: string;
-									structure: { __typename?: 'structure'; name?: string | null | undefined };
+									structure: { __typename?: 'structure'; name: string };
 							  }
 							| null
 							| undefined;
@@ -13656,7 +13657,7 @@ export type GetNotebookByIdQuery = {
 									structure: {
 										__typename?: 'structure';
 										id: string;
-										name?: string | null | undefined;
+										name: string;
 										address1?: string | null | undefined;
 										address2?: string | null | undefined;
 										postalCode?: string | null | undefined;
@@ -13686,7 +13687,7 @@ export type GetNotebookByIdQuery = {
 									__typename?: 'professional';
 									firstname: string;
 									lastname: string;
-									structure: { __typename?: 'structure'; name?: string | null | undefined };
+									structure: { __typename?: 'structure'; name: string };
 							  }
 							| null
 							| undefined;
@@ -13710,7 +13711,7 @@ export type GetNotebookByIdQuery = {
 										__typename?: 'professional';
 										firstname: string;
 										lastname: string;
-										structure: { __typename?: 'structure'; name?: string | null | undefined };
+										structure: { __typename?: 'structure'; name: string };
 								  }
 								| null
 								| undefined;
@@ -13735,7 +13736,7 @@ export type GetNotebookByIdQuery = {
 											__typename?: 'professional';
 											firstname: string;
 											lastname: string;
-											structure: { __typename?: 'structure'; name?: string | null | undefined };
+											structure: { __typename?: 'structure'; name: string };
 									  }
 									| null
 									| undefined;
@@ -13816,7 +13817,7 @@ export type NotebookFragmentFragment = {
 						structure: {
 							__typename?: 'structure';
 							id: string;
-							name?: string | null | undefined;
+							name: string;
 							address1?: string | null | undefined;
 							address2?: string | null | undefined;
 							postalCode?: string | null | undefined;
@@ -13846,7 +13847,7 @@ export type NotebookFragmentFragment = {
 						__typename?: 'professional';
 						firstname: string;
 						lastname: string;
-						structure: { __typename?: 'structure'; name?: string | null | undefined };
+						structure: { __typename?: 'structure'; name: string };
 				  }
 				| null
 				| undefined;
@@ -13870,7 +13871,7 @@ export type NotebookFragmentFragment = {
 							__typename?: 'professional';
 							firstname: string;
 							lastname: string;
-							structure: { __typename?: 'structure'; name?: string | null | undefined };
+							structure: { __typename?: 'structure'; name: string };
 					  }
 					| null
 					| undefined;
@@ -13895,7 +13896,7 @@ export type NotebookFragmentFragment = {
 								__typename?: 'professional';
 								firstname: string;
 								lastname: string;
-								structure: { __typename?: 'structure'; name?: string | null | undefined };
+								structure: { __typename?: 'structure'; name: string };
 						  }
 						| null
 						| undefined;
@@ -13930,7 +13931,7 @@ export type GetStructuresQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetStructuresQuery = {
 	__typename?: 'query_root';
-	structure: Array<{ __typename?: 'structure'; id: string; name?: string | null | undefined }>;
+	structure: Array<{ __typename?: 'structure'; id: string; name: string }>;
 };
 
 export type InsertProfessionalAccountMutationVariables = Exact<{
@@ -13944,10 +13945,7 @@ export type InsertProfessionalAccountMutation = {
 				__typename?: 'account';
 				id: string;
 				professional?:
-					| {
-							__typename?: 'professional';
-							structure: { __typename?: 'structure'; name?: string | null | undefined };
-					  }
+					| { __typename?: 'professional'; structure: { __typename?: 'structure'; name: string } }
 					| null
 					| undefined;
 		  }
@@ -14022,7 +14020,7 @@ export type GetDeploymentInfosQuery = {
 	structuresWithPros: Array<{
 		__typename?: 'structure';
 		id: string;
-		name?: string | null | undefined;
+		name: string;
 		professionals: Array<{
 			__typename?: 'professional';
 			id: string;
@@ -14077,7 +14075,7 @@ export type GetAccountsSummaryQuery = {
 					position?: string | null | undefined;
 					mobileNumber?: string | null | undefined;
 					email: string;
-					structure: { __typename?: 'structure'; id: string; name?: string | null | undefined };
+					structure: { __typename?: 'structure'; id: string; name: string };
 			  }
 			| null
 			| undefined;
@@ -14123,7 +14121,7 @@ export type GetNotebooksStatsQuery = {
 	structConnections: Array<{
 		__typename?: 'structure';
 		id: string;
-		name?: string | null | undefined;
+		name: string;
 		city?: string | null | undefined;
 		professionals_aggregate: {
 			__typename?: 'professional_aggregate';
@@ -14321,7 +14319,7 @@ export type GetNotebookQuery = {
 									structure: {
 										__typename?: 'structure';
 										id: string;
-										name?: string | null | undefined;
+										name: string;
 										address1?: string | null | undefined;
 										address2?: string | null | undefined;
 										postalCode?: string | null | undefined;
@@ -14362,7 +14360,7 @@ export type GetNotebookQuery = {
 							| {
 									__typename?: 'professional';
 									structureId: string;
-									structure: { __typename?: 'structure'; name?: string | null | undefined };
+									structure: { __typename?: 'structure'; name: string };
 							  }
 							| null
 							| undefined;
@@ -14394,7 +14392,7 @@ export type GetNotebookEventsQuery = {
 				| {
 						__typename?: 'professional';
 						structureId: string;
-						structure: { __typename?: 'structure'; name?: string | null | undefined };
+						structure: { __typename?: 'structure'; name: string };
 				  }
 				| null
 				| undefined;
@@ -14415,7 +14413,7 @@ export type EventFieldsFragment = {
 			| {
 					__typename?: 'professional';
 					structureId: string;
-					structure: { __typename?: 'structure'; name?: string | null | undefined };
+					structure: { __typename?: 'structure'; name: string };
 			  }
 			| null
 			| undefined;
@@ -14603,7 +14601,7 @@ export type GetStructureQuery = {
 		| {
 				__typename?: 'structure';
 				id: string;
-				name?: string | null | undefined;
+				name: string;
 				phone?: string | null | undefined;
 				email?: string | null | undefined;
 				address1?: string | null | undefined;
@@ -14662,7 +14660,7 @@ export type GetManagedStructuresQuery = {
 		__typename?: 'structure';
 		id: string;
 		city?: string | null | undefined;
-		name?: string | null | undefined;
+		name: string;
 		beneficiaries_aggregate: {
 			__typename?: 'beneficiary_structure_aggregate';
 			aggregate?:
@@ -18296,7 +18294,10 @@ export const ImportStructureDocument = {
 				{
 					kind: 'VariableDefinition',
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'name' } },
-					type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+					type: {
+						kind: 'NonNullType',
+						type: { kind: 'NamedType', name: { kind: 'Name', value: 'citext' } },
+					},
 				},
 				{
 					kind: 'VariableDefinition',
@@ -19626,6 +19627,11 @@ export const SearchProfessionalDocument = {
 				},
 				{
 					kind: 'VariableDefinition',
+					variable: { kind: 'Variable', name: { kind: 'Name', value: 'searchStructure' } },
+					type: { kind: 'NamedType', name: { kind: 'Name', value: 'citext' } },
+				},
+				{
+					kind: 'VariableDefinition',
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'accountIds' } },
 					type: {
 						kind: 'ListType',
@@ -19721,7 +19727,7 @@ export const SearchProfessionalDocument = {
 																						name: { kind: 'Name', value: '_ilike' },
 																						value: {
 																							kind: 'Variable',
-																							name: { kind: 'Name', value: 'search' },
+																							name: { kind: 'Name', value: 'searchStructure' },
 																						},
 																					},
 																				],
@@ -19921,7 +19927,7 @@ export const SearchProfessionalDocument = {
 																						name: { kind: 'Name', value: '_ilike' },
 																						value: {
 																							kind: 'Variable',
-																							name: { kind: 'Name', value: 'search' },
+																							name: { kind: 'Name', value: 'searchStructure' },
 																						},
 																					},
 																				],
@@ -21373,7 +21379,7 @@ export const UpdateStructureDocument = {
 				{
 					kind: 'VariableDefinition',
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'name' } },
-					type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+					type: { kind: 'NamedType', name: { kind: 'Name', value: 'citext' } },
 				},
 				{
 					kind: 'VariableDefinition',
@@ -22986,7 +22992,10 @@ export const InsertStructureDocument = {
 				{
 					kind: 'VariableDefinition',
 					variable: { kind: 'Variable', name: { kind: 'Name', value: 'name' } },
-					type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+					type: {
+						kind: 'NonNullType',
+						type: { kind: 'NamedType', name: { kind: 'Name', value: 'citext' } },
+					},
 				},
 				{
 					kind: 'VariableDefinition',

--- a/app/src/lib/ui/Manager/_importStructure.gql
+++ b/app/src/lib/ui/Manager/_importStructure.gql
@@ -1,57 +1,57 @@
 mutation ImportStructure(
-	$name: String
-	$phone: String
-	$email: String
-	$address1: String
-	$address2: String
-	$postalCode: String
-	$city: String
-	$website: String
-	$siret: String
-	$shortDesc: String
-	$adminEmail: citext
-	$firstname: String
-	$lastname: String
-	$position: String
-	$phoneNumbers: String
-	$forceUpdate: Boolean
-	$sendAccountEmail: Boolean
+  $name: citext!
+  $phone: String
+  $email: String
+  $address1: String
+  $address2: String
+  $postalCode: String
+  $city: String
+  $website: String
+  $siret: String
+  $shortDesc: String
+  $adminEmail: citext
+  $firstname: String
+  $lastname: String
+  $position: String
+  $phoneNumbers: String
+  $forceUpdate: Boolean
+  $sendAccountEmail: Boolean
 ) {
-	structure: insertStructureWithAdmin(
-		data: {
-			structure: {
-				name: $name
-				phone: $phone
-				email: $email
-				address1: $address1
-				address2: $address2
-				postalCode: $postalCode
-				city: $city
-				website: $website
-				siret: $siret
-				shortDesc: $shortDesc
-			}
-			adminStructure: {
-				adminEmail: $adminEmail
-				firstname: $firstname
-				lastname: $lastname
-				position: $position
-				phoneNumbers: $phoneNumbers
-			}
-			forceUpdate: $forceUpdate
-			sendAccountEmail: $sendAccountEmail
-		}
-	) {
-		id
-		# name
-		# phone
-		# email
-		# address1
-		# address2
-		# postalCode
-		# city
-		# website
-		# siret
-		# shortDesc
-	}
+  structure: insertStructureWithAdmin(
+    data: {
+      structure: {
+        name: $name
+        phone: $phone
+        email: $email
+        address1: $address1
+        address2: $address2
+        postalCode: $postalCode
+        city: $city
+        website: $website
+        siret: $siret
+        shortDesc: $shortDesc
+      }
+      adminStructure: {
+        adminEmail: $adminEmail
+        firstname: $firstname
+        lastname: $lastname
+        position: $position
+        phoneNumbers: $phoneNumbers
+      }
+      forceUpdate: $forceUpdate
+      sendAccountEmail: $sendAccountEmail
+    }
+  ) {
+    id
+    # name
+    # phone
+    # email
+    # address1
+    # address2
+    # postalCode
+    # city
+    # website
+    # siret
+    # shortDesc
+  }
 }

--- a/app/src/lib/ui/ProNotebookMember/ProNotebookMemberInvitation.svelte
+++ b/app/src/lib/ui/ProNotebookMember/ProNotebookMemberInvitation.svelte
@@ -33,7 +33,7 @@
 
 	const searchProfessionalResult = operationStore(
 		SearchProfessionalDocument,
-		{ search: null },
+		{ search: null, searchStructure: null },
 		{ pause: true }
 	);
 
@@ -47,6 +47,7 @@
 		$searchProfessionalResult.context.pause = false;
 		$searchProfessionalResult.variables = {
 			search: `%${search}%`,
+			searchStructure: `%${search}%`,
 			accountIds,
 		};
 		$searchProfessionalResult.reexecute();

--- a/app/src/lib/ui/ProNotebookMember/_SearchProfessional.gql
+++ b/app/src/lib/ui/ProNotebookMember/_SearchProfessional.gql
@@ -1,10 +1,10 @@
-query SearchProfessional($search: String, $accountIds: [uuid!] = []) {
+query SearchProfessional($search: String, $searchStructure: citext, $accountIds: [uuid!] = []) {
   professionals: professional(
     where: {
       _or: [
         { firstname: { _ilike: $search } }
         { lastname: { _ilike: $search } }
-        { structure: { name: { _ilike: $search } } }
+        { structure: { name: { _ilike: $searchStructure } } }
         { structure: { postalCode: { _ilike: $search } } }
       ]
       _not: { account: { id: { _in: $accountIds } } }
@@ -29,7 +29,7 @@ query SearchProfessional($search: String, $accountIds: [uuid!] = []) {
       _or: [
         { firstname: { _ilike: $search } }
         { lastname: { _ilike: $search } }
-        { structure: { name: { _ilike: $search } } }
+        { structure: { name: { _ilike: $searchStructure } } }
         { structure: { postalCode: { _ilike: $search } } }
       ]
       _not: { account: { id: { _in: $accountIds } } }

--- a/app/src/lib/ui/ProNotebookMember/_SearchProfessional.gql
+++ b/app/src/lib/ui/ProNotebookMember/_SearchProfessional.gql
@@ -1,3 +1,6 @@
+# we use 2 search field type since hasura don't
+# let us use a string for citext search
+# https://github.com/hasura/graphql-engine/issues/9081
 query SearchProfessional($search: String, $searchStructure: citext, $accountIds: [uuid!] = []) {
   professionals: professional(
     where: {

--- a/app/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
+++ b/app/src/lib/ui/ProfessionalList/_getProfessionalsForStructure.gql
@@ -1,4 +1,5 @@
 query GetProfessionalsForStructure($structureId: uuid!) {
+<<<<<<< HEAD
 	professional(
     where: { structureId: { _eq: $structureId }, account: { deletedAt: { _is_null: true } } }
     order_by: [{firstname: asc}, {lastname: asc}, {email: asc}]
@@ -8,6 +9,24 @@ query GetProfessionalsForStructure($structureId: uuid!) {
 		lastname
 		mobileNumber
 		email
+||||||| parent of 5d84df22 (fix: update name colum, to be case insensitive)
+	professional(where: { structureId: { _eq: $structureId } } order_by: [{firstname, asc}, {lastname: asc}, {emaill: asc}]) {
+		id
+		firstname
+		lastname
+		mobileNumber
+		email
+=======
+  professional(
+    where: { structureId: { _eq: $structureId } }
+    order_by: [{ firstname: asc }, { lastname: asc }, { email: asc }]
+  ) {
+    id
+    firstname
+    lastname
+    mobileNumber
+    email
+>>>>>>> 5d84df22 (fix: update name colum, to be case insensitive)
     position
     account {
       id
@@ -18,5 +37,5 @@ query GetProfessionalsForStructure($structureId: uuid!) {
         }
       }
     }
-	}
+  }
 }

--- a/app/src/lib/ui/StructureEdit/updateStructure.gql
+++ b/app/src/lib/ui/StructureEdit/updateStructure.gql
@@ -8,7 +8,7 @@ mutation updateStructure(
   $shortDesc: String
   $siret: String
   $phone: String
-  $name: String
+  $name: citext
   $email: String
 ) {
   update_structure_by_pk(

--- a/app/src/routes/actions/_insertStructure.gql
+++ b/app/src/routes/actions/_insertStructure.gql
@@ -1,31 +1,31 @@
 mutation InsertStructure(
-	$name: String
-	$phone: String
-	$email: String
-	$address1: String
-	$address2: String
-	$postalCode: String
-	$city: String
-	$website: String
-	$siret: String
-	$shortDesc: String
-	$onConflict: structure_on_conflict
+  $name: citext!
+  $phone: String
+  $email: String
+  $address1: String
+  $address2: String
+  $postalCode: String
+  $city: String
+  $website: String
+  $siret: String
+  $shortDesc: String
+  $onConflict: structure_on_conflict
 ) {
-	structure: insert_structure_one(
-		on_conflict: $onConflict
-		object: {
-			name: $name
-			phone: $phone
-			email: $email
-			address1: $address1
-			address2: $address2
-			postalCode: $postalCode
-			city: $city
-			website: $website
-			siret: $siret
-			shortDesc: $shortDesc
-		}
-	) {
-		id
-	}
+  structure: insert_structure_one(
+    on_conflict: $onConflict
+    object: {
+      name: $name
+      phone: $phone
+      email: $email
+      address1: $address1
+      address2: $address2
+      postalCode: $postalCode
+      city: $city
+      website: $website
+      siret: $siret
+      shortDesc: $shortDesc
+    }
+  ) {
+    id
+  }
 }

--- a/backend/api/core/emails.py
+++ b/backend/api/core/emails.py
@@ -2,6 +2,7 @@ from urllib import parse
 from uuid import UUID
 
 from api.core.jinja import jinja_env
+from api.core.sendmail import send_mail
 from api.core.settings import settings
 
 
@@ -14,7 +15,7 @@ def create_magic_link(access_key: UUID, redirect_path: str | None = None) -> str
 
 
 def generic_account_creation_email(
-    username: str, firstname: str | None, lastname: str | None, access_key: str
+    username: str, firstname: str | None, lastname: str | None, access_key: UUID
 ) -> str:
     template = jinja_env.get_template("generic_account_creation_email.html")
     return template.render(
@@ -23,3 +24,10 @@ def generic_account_creation_email(
         url=create_magic_link(access_key=access_key),
         username=username,
     )
+
+
+def send_invitation_email(
+    email: str, firstname: str | None, lastname: str | None, access_key: UUID
+) -> None:
+    message = generic_account_creation_email(email, firstname, lastname, access_key)
+    send_mail(email, "Création de compte sur Carnet de bord", message)

--- a/backend/api/core/exceptions.py
+++ b/backend/api/core/exceptions.py
@@ -1,0 +1,4 @@
+class InsertFailError(Exception):
+    """
+    utility class when insert goes wrong
+    """

--- a/backend/api/core/sendmail.py
+++ b/backend/api/core/sendmail.py
@@ -23,7 +23,7 @@ def send_mail(to: str, subject: str, message: str) -> None:
     part1 = MIMEText(html, "html")
 
     msg.attach(part1)
-    s = smtplib.SMTP(settings.smtp_host, settings.smtp_port)
+    s = smtplib.SMTP(settings.smtp_host, int(settings.smtp_port))
 
     s.set_debuglevel(True)
 
@@ -34,7 +34,15 @@ def send_mail(to: str, subject: str, message: str) -> None:
         s.login(settings.smtp_user, settings.smtp_pass)
     try:
         s.sendmail(msg["From"], msg["To"], msg.as_string())
-    except Exception as e:
-        logging.error("send mail error", e)
+    except smtplib.SMTPRecipientsRefused as err:
+        logging.error("sendmail error: %s", err)
+    except smtplib.SMTPHeloError as err:
+        logging.error("sendmail error: %s", err)
+    except smtplib.SMTPSenderRefused as err:
+        logging.error("sendmail error: %s", err)
+    except smtplib.SMTPDataError as err:
+        logging.error("sendmail error: %s", err)
+    except smtplib.SMTPNotSupportedError as err:
+        logging.error("send mail error %s", err)
     finally:
         s.quit()

--- a/backend/api/db/crud/manager.py
+++ b/backend/api/db/crud/manager.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from asyncpg import Record
 from asyncpg.connection import Connection
 
-from api.db.models.manager import Manager
+from api.db.models.manager import Manager, ManagerInput
 
 
 def parse_manager_from_record(record: Record) -> Manager:
@@ -14,7 +14,7 @@ def parse_manager_from_record(record: Record) -> Manager:
 
 async def insert_admin_pdi(
     connection: Connection,
-    data: Manager,
+    data: ManagerInput,
 ) -> Manager | None:
     record = await connection.fetchrow(
         """
@@ -31,7 +31,7 @@ async def insert_admin_pdi(
     if record:
         return parse_manager_from_record(record)
     else:
-        logging.error(f"insert fail {data}")
+        logging.error("insert fail %s", data)
 
 
 async def get_managers_from_deployment(

--- a/backend/api/db/crud/orientation_manager.py
+++ b/backend/api/db/crud/orientation_manager.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Tuple
 from uuid import UUID
 
 from asyncpg import Record
@@ -10,6 +10,12 @@ from api.db.models.orientation_manager import (
     OrientationManagerCsvRow,
     OrientationManagerDB,
 )
+from api.db.crud.account import (
+    create_username,
+    get_accounts_with_query,
+    insert_orientation_manager_account,
+)
+from api.db.models.account import AccountDB, AccountDBWithAccessKey
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
@@ -45,10 +51,11 @@ async def insert_orientation_manager(
         data.phone_numbers,
     )
 
-    if record:
-        return parse_orientation_manager_from_record(record)
-    else:
-        logging.error(f"insert fail {data}")
+    if not record:
+        logging.error("insert fail %s", data)
+        return None
+
+    return parse_orientation_manager_from_record(record)
 
 
 async def get_orientation_managers(
@@ -62,3 +69,49 @@ async def get_orientation_managers(
     )
 
     return [parse_orientation_manager_from_record(record) for record in records]
+
+
+async def create_orientation_manager_with_account(
+    connection: Connection, data: OrientationManagerCsvRow, deployment_id: UUID
+) -> Tuple[AccountDBWithAccessKey, OrientationManagerDB] | None:
+    """
+    Creation d'un profil admin_structure et du compte associé
+    """
+    async with connection.transaction():
+        orientation_manager: OrientationManagerDB | None = (
+            await insert_orientation_manager(
+                connection=connection, deployment_id=deployment_id, data=data
+            )
+        )
+
+        if not orientation_manager:
+            logging.error("Insert orientation manager %s failed", data.email)
+            return None
+
+        email_username: str = data.email.split("@")[0].lower()
+
+        accounts: List[AccountDB] = await get_accounts_with_query(
+            connection,
+            """
+            WHERE account.username like $1
+            """,
+            email_username + "%",
+        )
+        username: str = create_username(
+            email_username, [account.username for account in accounts]
+        )
+
+        account: AccountDBWithAccessKey | None = (
+            await insert_orientation_manager_account(
+                connection=connection,
+                username=orientation_manager.email,
+                confirmed=True,
+                orientation_manager_id=orientation_manager.id,
+            )
+        )
+
+        if not account:
+            logging.error("Insert admin structure account failed for %s", username)
+            return None
+
+        return account, orientation_manager

--- a/backend/api/db/crud/orientation_manager.py
+++ b/backend/api/db/crud/orientation_manager.py
@@ -6,16 +6,16 @@ from asyncpg import Record
 from asyncpg.connection import Connection
 
 from api.core.settings import settings
-from api.db.models.orientation_manager import (
-    OrientationManagerCsvRow,
-    OrientationManagerDB,
-)
 from api.db.crud.account import (
     create_username,
     get_accounts_with_query,
     insert_orientation_manager_account,
 )
 from api.db.models.account import AccountDB, AccountDBWithAccessKey
+from api.db.models.orientation_manager import (
+    OrientationManagerCsvRow,
+    OrientationManagerDB,
+)
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 

--- a/backend/api/db/models/account.py
+++ b/backend/api/db/models/account.py
@@ -25,6 +25,11 @@ class AccountDB(BaseModel):
     updated_at: datetime
 
 
+class AccountDBWithAccessKey(AccountDB):
+    access_key: UUID
+    access_key_date: datetime
+
+
 class AccountInfo(BaseModel):
     account_id: UUID
     firstname: str

--- a/backend/api/db/models/structure.py
+++ b/backend/api/db/models/structure.py
@@ -53,6 +53,7 @@ class StructureInputRow(BaseModel):
 
     class Config:
         anystr_strip_whitespace = True
+        allow_population_by_field_name = True
 
     @validator("siret", allow_reuse=True)
     def must_be_a_valid_siret(cls, value: str) -> str:
@@ -124,3 +125,21 @@ def map_csv_row(row: Series) -> StructureCsvRowResponse:
             valid=True,
             errors=[CsvFieldError(error=str(error))],
         )
+
+
+def map_input_row_to_structure_insert(
+    structure: StructureInputRow, deployment_id: UUID
+) -> StructureInsert:
+    return StructureInsert(
+        siret=structure.siret,
+        name=structure.name,
+        short_desc=structure.short_desc,
+        phone=structure.phone,
+        email=structure.email,
+        postal_code=structure.postal_code,
+        city=structure.city,
+        address1=structure.address1,
+        address2=structure.address2,
+        website=structure.website,
+        deployment_id=deployment_id,
+    )

--- a/backend/api/v1/main.py
+++ b/backend/api/v1/main.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from api.v1.routers import admin_structures, csv2json, managers, uploads
+from api.v1.routers import admin_structures, csv2json, managers, structures, uploads
 
 api_router = APIRouter()
 api_router.include_router(uploads.router, prefix="/uploads", tags=["uploads"])
@@ -11,4 +11,4 @@ api_router.include_router(
 api_router.include_router(
     csv2json.router, prefix="/convert-file", tags=["Csv to Json parsing"]
 )
-api_router.include_router(csv2json.router, prefix="/structures", tags=["structures"])
+api_router.include_router(structures.router, prefix="/structures", tags=["structures"])

--- a/backend/api/v1/routers/admin_structures.py
+++ b/backend/api/v1/routers/admin_structures.py
@@ -2,22 +2,20 @@ import logging
 from typing import Tuple
 from uuid import UUID
 
-from asyncpg.exceptions import UniqueViolationError
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
+from api.core.emails import send_invitation_email
 from api.core.init import connection
 from api.core.settings import settings
 from api.db.crud.admin_structure import (
-    InsertFailError,
     create_admin_structure_with_account,
-    get_admin_structure_with_query,
+    get_admin_structure_by_email,
     insert_admin_structure_structure,
 )
 from api.db.models.account import AccountDB
 from api.db.models.admin_structure import AdminStructure, AdminStructureStructureInput
 from api.db.models.role import RoleEnum
 from api.v1.dependencies import allowed_jwt_roles
-from api.core.emails import send_invitation_email
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
@@ -33,60 +31,39 @@ async def create_admin_structure(
     db=Depends(connection),
 ):
     async with db.transaction():
-        admin_structure: AdminStructure | None = await get_admin_structure_with_query(
+        admin_structure: AdminStructure | None = await get_admin_structure_by_email(
             db,
-            """
-            , public.account
-            WHERE account.admin_structure_id = admin_structure.id
-            AND admin_structure.email = $1
-            """,
             data.admin.email,
         )
         if not admin_structure:
-            try:
-                account_admin_tuple: Tuple[
-                    AccountDB, AdminStructure
-                ] = await create_admin_structure_with_account(db, data)
-                account, admin_structure = account_admin_tuple
 
-                background_tasks.add_task(
-                    send_invitation_email,
-                    email=admin_structure.email,
-                    firstname=admin_structure.firstname,
-                    lastname=admin_structure.lastname,
-                    access_key=account.access_key,
-                )
+            account_admin_tuple: Tuple[
+                AccountDB, AdminStructure
+            ] | None = await create_admin_structure_with_account(db, data)
 
-            except InsertFailError as error:
-                logging.error(error)
+            if not account_admin_tuple:
                 raise HTTPException(
                     status_code=500,
-                    detail=error,
-                ) from error
+                    detail="insert admin_structure failed",
+                )
+            account, admin_structure = account_admin_tuple
 
-            except Exception as error:
-                logging.error(error)
-                raise HTTPException(
-                    status_code=500, detail="fail to create admin structure structure"
-                ) from error
-        try:
-
-            ass_id: UUID | None = await insert_admin_structure_structure(
-                connection=db,
-                admin_structure_id=admin_structure.id,
-                structure_id=data.structure_id,
+            background_tasks.add_task(
+                send_invitation_email,
+                email=admin_structure.email,
+                firstname=admin_structure.firstname,
+                lastname=admin_structure.lastname,
+                access_key=account.access_key,
             )
 
-            if not ass_id:
-                logging.error(f"Insert admin_structure_structure failed")
-                raise HTTPException(
-                    status_code=500,
-                    detail="insert admin_structure_structure failed",
-                )
-            return admin_structure
+        ass_id: UUID | None = await insert_admin_structure_structure(
+            connection=db,
+            admin_structure_id=admin_structure.id,
+            structure_id=data.structure_id,
+        )
 
-        except Exception as error:
-            logging.error("insert fail {}".format(error))
+        if not ass_id:
+            logging.error("Insert admin_structure_structure failed")
             raise HTTPException(
                 status_code=500,
                 detail="insert admin_structure_structure failed",

--- a/backend/api/v1/routers/admin_structures.py
+++ b/backend/api/v1/routers/admin_structures.py
@@ -5,7 +5,6 @@ from uuid import UUID
 from asyncpg.exceptions import UniqueViolationError
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
-from api.core.emails import generic_account_creation_email
 from api.core.init import connection
 from api.core.settings import settings
 from api.db.crud.admin_structure import (
@@ -17,8 +16,8 @@ from api.db.crud.admin_structure import (
 from api.db.models.account import AccountDB
 from api.db.models.admin_structure import AdminStructure, AdminStructureStructureInput
 from api.db.models.role import RoleEnum
-from api.sendmail import send_mail
 from api.v1.dependencies import allowed_jwt_roles
+from api.core.emails import send_invitation_email
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
@@ -89,15 +88,7 @@ async def create_admin_structure(
         except Exception as error:
             logging.error("insert fail {}".format(error))
             raise HTTPException(
-                status_code=500, detail="fail to create admin structure structure"
-            ) from error
-
-
-def send_invitation_email(
-    email: str, firstname: str | None, lastname: str | None, access_key: UUID
-) -> None:
-    """
-    gestion de l'envoi de mail depuis un template
-    """
-    message = generic_account_creation_email(email, firstname, lastname, access_key)
-    send_mail(email, "Création de compte sur Carnet de bord", message)
+                status_code=500,
+                detail="insert admin_structure_structure failed",
+            )
+        return admin_structure

--- a/backend/api/v1/routers/managers.py
+++ b/backend/api/v1/routers/managers.py
@@ -4,8 +4,8 @@ from http.client import HTTPException
 
 from fastapi import APIRouter, BackgroundTasks, Depends
 
-from api.core.emails import generic_account_creation_email
 from api.core.init import connection
+from api.core.emails import send_invitation_email
 from api.core.settings import settings
 from api.db.crud.account import (
     create_username,
@@ -15,7 +15,6 @@ from api.db.crud.account import (
 from api.db.crud.manager import insert_admin_pdi
 from api.db.models.manager import Manager, ManagerInput
 from api.db.models.role import RoleEnum
-from api.sendmail import send_mail
 from api.v1.dependencies import allowed_jwt_roles
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
@@ -69,10 +68,3 @@ async def create_manager(
             access_key=account.access_key,
         )
         return admin_pdi
-
-
-def send_invitation_email(
-    email: str, firstname: str | None, lastname: str | None, access_key: uuid.UUID
-) -> None:
-    message = generic_account_creation_email(email, firstname, lastname, access_key)
-    send_mail(email, "Création de compte sur Carnet de bord", message)

--- a/backend/api/v1/routers/structures.py
+++ b/backend/api/v1/routers/structures.py
@@ -1,0 +1,141 @@
+import logging
+from typing import Tuple
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
+from pydantic import BaseModel
+
+from api.core.exceptions import InsertFailError
+from api.core.init import connection
+from api.core.settings import settings
+from api.db.crud.admin_structure import (
+    create_admin_structure_with_account,
+    get_admin_structure_by_email,
+    insert_admin_structure_structure,
+)
+from api.db.crud.structure import get_structure_by_name, insert_structure
+from api.db.models.account import AccountDBWithAccessKey
+from api.db.models.admin_structure import (
+    AdminStructure,
+    AdminStructureInput,
+    AdminStructureStructureInput,
+)
+from api.db.models.role import RoleEnum
+from api.db.models.structure import (
+    CsvFieldError,
+    Structure,
+    StructureCsvRowResponse,
+    StructureInputRow,
+    map_input_row_to_structure_insert,
+)
+from api.v1.dependencies import allowed_jwt_roles, extract_deployment_id
+from api.v1.routers.admin_structures import send_invitation_email
+
+logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
+
+admin_only = allowed_jwt_roles([RoleEnum.MANAGER])
+
+router = APIRouter(dependencies=[Depends(admin_only), Depends(extract_deployment_id)])
+
+
+class StructuresInputRow(BaseModel):
+    structures: list[StructureInputRow]
+
+
+@router.post("/import", response_model=list[StructureCsvRowResponse])
+async def create_structures(
+    data: StructuresInputRow,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db=Depends(connection),
+):
+    deployment_id = request.state.deployment_id
+    result: list[StructureCsvRowResponse] = []
+    for structure_row in data.structures:
+        try:
+            async with db.transaction():
+                structure: Structure | None = await get_structure_by_name(
+                    db, structure_row.name
+                )
+
+                # 1 create structure if not exist
+                if not structure:
+                    structure = await insert_structure(
+                        db,
+                        map_input_row_to_structure_insert(structure_row, deployment_id),
+                    )
+                if not structure:
+                    raise InsertFailError("insert structure failed")
+
+                # 2 Create admin structure if not exist
+                admin_structure: AdminStructure | None = (
+                    await get_admin_structure_by_email(
+                        db,
+                        structure_row.admin_email,
+                    )
+                )
+
+                if not admin_structure:
+                    account_admin_tuple: Tuple[
+                        AccountDBWithAccessKey, AdminStructure
+                    ] | None = await create_admin_structure_with_account(
+                        db,
+                        AdminStructureStructureInput(
+                            admin=AdminStructureInput(
+                                firstname=structure_row.admin_firstname,
+                                lastname=structure_row.admin_lastname,
+                                phone_numbers=structure_row.admin_phone_number,
+                                position=structure_row.admin_position,
+                                email=structure_row.admin_email,
+                                deployment_id=deployment_id,
+                            ),
+                            structure_id=structure.id,
+                        ),
+                    )
+                    if not account_admin_tuple:
+                        raise InsertFailError("insert structure admin failed")
+
+                    account, admin_structure = account_admin_tuple
+
+                    background_tasks.add_task(
+                        send_invitation_email,
+                        email=admin_structure.email,
+                        firstname=admin_structure.firstname,
+                        lastname=admin_structure.lastname,
+                        access_key=account.access_key,
+                    )
+
+                # 3 Assign admin structure to structure
+
+                uuid = await insert_admin_structure_structure(
+                    connection=db,
+                    admin_structure_id=admin_structure.id,
+                    structure_id=structure.id,
+                )
+                if not uuid:
+                    raise InsertFailError("add admin structure to structure failed")
+                response_row = StructureCsvRowResponse(valid=True, data=structure_row)
+        except InsertFailError as error:
+            logging.error(error)
+            response_row = StructureCsvRowResponse(
+                row=structure_row.dict(),
+                errors=[
+                    CsvFieldError(
+                        error=f"import structure {structure_row.name}: {error}"
+                    )
+                ],
+                valid=False,
+            )
+        except Exception as error:
+            logging.error("unhandled exception %s", error)
+            response_row = StructureCsvRowResponse(
+                row=structure_row.dict(),
+                errors=[
+                    CsvFieldError(
+                        error=f"import structure {structure_row.name}: erreur inconnue"
+                    )
+                ],
+                valid=False,
+            )
+        result.append(response_row)
+
+    return result

--- a/backend/api/v1/routers/uploads.py
+++ b/backend/api/v1/routers/uploads.py
@@ -20,7 +20,6 @@ from fastapi import (
 from pandas.core.series import Series
 from pydantic import ValidationError
 
-from api.core.emails import generic_account_creation_email
 from api.core.init import connection
 from api.core.settings import settings
 from api.db.crud.account import insert_orientation_manager_account
@@ -33,8 +32,9 @@ from api.db.models.orientation_manager import (
     map_row_response,
 )
 from api.db.models.role import RoleEnum
-from api.sendmail import send_mail
+
 from api.v1.dependencies import allowed_jwt_roles, extract_deployment_id
+from api.core.emails import send_invitation_email
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 
@@ -148,8 +148,3 @@ async def create_orientation_manager(
             return account
 
 
-def send_invitation_email(
-    email: str, firstname: str | None, lastname: str | None, access_key: UUID
-) -> None:
-    message = generic_account_creation_email(email, firstname, lastname, access_key)
-    send_mail(email, "Création de compte sur Carnet de bord", message)

--- a/backend/api/v1/routers/uploads.py
+++ b/backend/api/v1/routers/uploads.py
@@ -19,8 +19,11 @@ from fastapi import (
 from pandas.core.series import Series
 from pydantic import ValidationError
 
+from api.core.emails import send_invitation_email
+from api.core.exceptions import InsertFailError
 from api.core.init import connection
 from api.core.settings import settings
+from api.db.crud.orientation_manager import create_orientation_manager_with_account
 from api.db.models.account import AccountDBWithAccessKey
 from api.db.models.orientation_manager import (
     OrientationManagerCsvRow,
@@ -30,13 +33,7 @@ from api.db.models.orientation_manager import (
     map_row_response,
 )
 from api.db.models.role import RoleEnum
-
 from api.v1.dependencies import allowed_jwt_roles, extract_deployment_id
-from api.core.exceptions import InsertFailError
-from api.db.crud.orientation_manager import (
-    create_orientation_manager_with_account,
-)
-from api.core.emails import send_invitation_email
 
 logging.basicConfig(level=logging.INFO, format=settings.LOG_FORMAT)
 

--- a/backend/tests/api/test_csv2json.py
+++ b/backend/tests/api/test_csv2json.py
@@ -31,3 +31,91 @@ async def test_parse_csv_errors(
         assert response.json()[1][3]["error_messages"] == [
             "Incorrect date format, The date must be formated as: YYYY-MM-DD"
         ]
+
+
+async def test_structure_parse_csv(
+    test_client,
+    csv_structure_filepath,
+    get_manager_jwt,
+):
+    with open(csv_structure_filepath, "rb") as file:
+        response = test_client.post(
+            "/v1/convert-file/structures",
+            files={"upload_file": ("filename", file, "text/csv")},
+            headers={"jwt-token": f"{get_manager_jwt}"},
+        )
+
+        data = response.json()
+        assert response.status_code == 200
+
+
+async def test_structure_parse_csv_with_error(
+    test_client,
+    csv_structure_buggy_filepath,
+    get_manager_jwt,
+):
+    with open(csv_structure_buggy_filepath, "rb") as file:
+        response = test_client.post(
+            "/v1/convert-file/structures",
+            files={"upload_file": ("filename", file, "text/csv")},
+            headers={"jwt-token": f"{get_manager_jwt}"},
+        )
+        data = response.json()
+
+        structure_with_errors = [
+            structure for structure in data if structure["valid"] is False
+        ]
+        assert len(structure_with_errors) == 3
+        assert structure_with_errors[0]["errors"][0]["key"] == "Nom"
+        assert (
+            structure_with_errors[0]["errors"][0]["error"]
+            == "none is not an allowed value"
+        )
+
+        assert len(structure_with_errors[1]["errors"]) == 3
+        assert structure_with_errors[1]["errors"][0]["key"] == "Site web"
+        assert (
+            structure_with_errors[1]["errors"][0]["error"]
+            == "invalid or missing URL scheme"
+        )
+        assert structure_with_errors[1]["errors"][1]["key"] == "Courriel"
+        assert (
+            structure_with_errors[1]["errors"][1]["error"]
+            == "value is not a valid email address"
+        )
+        assert structure_with_errors[1]["errors"][2]["key"] == "Courriel responsable"
+        assert (
+            structure_with_errors[1]["errors"][2]["error"]
+            == "value is not a valid email address"
+        )
+
+        assert len(structure_with_errors[2]["errors"]) == 2
+        assert structure_with_errors[2]["errors"][0]["key"] == "Site web"
+        assert (
+            structure_with_errors[2]["errors"][0]["error"]
+            == "invalid or missing URL scheme"
+        )
+        assert structure_with_errors[2]["errors"][1]["key"] == "Courriel responsable"
+        assert (
+            structure_with_errors[2]["errors"][1]["error"]
+            == "value is not a valid email address"
+        )
+
+
+async def test_structure_parse_csv_with_missing_column_should_not_fail(
+    test_client,
+    csv_structure_missing_key_filepath,
+    get_manager_jwt,
+):
+    with open(csv_structure_missing_key_filepath, "rb") as file:
+        response = test_client.post(
+            "/v1/convert-file/structures",
+            files={"upload_file": ("filename", file, "text/csv")},
+            headers={"jwt-token": f"{get_manager_jwt}"},
+        )
+        data = response.json()
+
+        structure_with_errors = [
+            structure for structure in data if structure["valid"] is False
+        ]
+        assert len(structure_with_errors) == 0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -241,3 +241,44 @@ def get_admin_cdb_jwt() -> str:
 @pytest.fixture
 def get_professionnal_jwt() -> str:
     return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2hhc3VyYS5pby9qd3QvY2xhaW1zIjp7IngtaGFzdXJhLWFsbG93ZWQtcm9sZXMiOlsicHJvZmVzc2lvbmFsIl0sIngtaGFzdXJhLWRlZmF1bHQtcm9sZSI6InByb2Zlc3Npb25hbCIsIngtaGFzdXJhLXVzZXItaWQiOiIxNzQzNDQ2NC01ZjY5LTQwY2MtODE3Mi00MDE2MDk1OGEzM2QiLCJ4LWhhc3VyYS1wcm9mZXNzaW9uYWwtaWQiOiIxYTViODE3Yi02YjgxLTRhNGQtOTk1My0yNjcwN2E1NGUwZTkiLCJ4LWhhc3VyYS1kZXBsb3ltZW50LWlkIjoiNGRhYjgwMzYtYTg2ZS00ZDVmLTliZDQtNmNlODhjMTk0MGQwIn0sImlkIjoiMTc0MzQ0NjQtNWY2OS00MGNjLTgxNzItNDAxNjA5NThhMzNkIiwicm9sZSI6InByb2Zlc3Npb25hbCIsInByb2Zlc3Npb25hbElkIjoiMWE1YjgxN2ItNmI4MS00YTRkLTk5NTMtMjY3MDdhNTRlMGU5IiwiZGVwbG95bWVudElkIjoiNGRhYjgwMzYtYTg2ZS00ZDVmLTliZDQtNmNlODhjMTk0MGQwIiwiaWF0IjoxNjYxODY2NzkzLCJleHAiOjE5Nzc0NDI3OTMsInN1YiI6IjE3NDM0NDY0LTVmNjktNDBjYy04MTcyLTQwMTYwOTU4YTMzZCJ9.sSj94JD2BvBjjUttMhfNQnVwvj6vOWnKW3Vkkbsskxs"
+
+
+@pytest.fixture
+def import_structures_json() -> list[dict]:
+    return [
+        {
+            "name": "ins'Hair",
+            "short_desc": "l'insertion par la coiffure",
+            "postal_code": "93001",
+            "city": "Livry Gargan",
+            "admin_email": "admin@inshair.fr",
+        },
+    ]
+
+
+@pytest.fixture
+def import_structures_json_with_errors() -> list[dict]:
+    return [
+        {
+            "name": "ins'Hair",
+            "short_desc": "l'insertion par la coiffure",
+            "postal_code": "93001",
+            "city": "Livry Gargan",
+            "admin_email": "admin@inshair.fr",
+        },
+        {
+            "name": "test",
+            "postal_code": "93001",
+            "admin_email": "admin@test93.fr",
+        },
+    ]
+
+
+@pytest.fixture
+def deployment_id_cd93() -> UUID:
+    return UUID("4dab8036-a86e-4d5f-9bd4-6ce88c1940d0")
+
+
+@pytest.fixture
+def structure_id_pe_livry() -> UUID:
+    return UUID("a81bc81b-dead-4e5d-abff-90865d1e13b2")

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -25,7 +25,7 @@ input InsertStructureWithAdminInput {
 }
 
 input StructureInput {
-  name: String
+  name: citext!
   phone: String
   email: String
   address1: String
@@ -52,7 +52,7 @@ type CreateDeploymentOutput {
 
 type InsertStructureWithAdminOutput {
   id: uuid!
-  name: String
+  name: citext
   phone: String
   email: citext
   address1: String

--- a/hasura/migrations/carnet_de_bord/1664790703990_alter_table_public_structure_alter_column_name/down.sql
+++ b/hasura/migrations/carnet_de_bord/1664790703990_alter_table_public_structure_alter_column_name/down.sql
@@ -1,0 +1,2 @@
+alter table "public"."structure" alter column "name" drop not null;
+ALTER TABLE "public"."structure" ALTER COLUMN "name" TYPE character varying;

--- a/hasura/migrations/carnet_de_bord/1664790703990_alter_table_public_structure_alter_column_name/up.sql
+++ b/hasura/migrations/carnet_de_bord/1664790703990_alter_table_public_structure_alter_column_name/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."structure" ALTER COLUMN "name" TYPE citext;
+alter table "public"."structure" alter column "name" set not null;


### PR DESCRIPTION
## :wrench: Problème

Actuellement l'import des structures est réalisé coté front, sans que les données soient validés / pré-traité, ce qui peut entraînait des problèmes de structure en double.

## :cake: Solution

Stocker les données dans la base avec un champ non sensible à la casse. 
Passer l'import coté backend et améliorer le pré-traitement des données.

## :rotating_light:  Points d'attention / Remarques
On profites de la PR pour uniformiser les pratiques (
- généralisation des return None dans les crud plutot que des `raise Error()`
- utilisation de `@mock.patch` pour simplifier l'écriture des tests
- utilisation de classe dédié pour les exceptions
- refactor du code lié à l'envoi de mail
- fix des requetes graphql (searchProfessionnal utilisant une variable `search:String` or pour hasura citext n'est pas compatible avec String)
- 
## :desert_island: Comment tester

Récupérer la branche et lancer le backend. se connecter au swagger du backend et lancer un import de structures

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1158.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
