### PR TITLE
feat(data): remove rqth from situations

### DIFF
--- a/hasura/migrations/carnet_de_bord/1665481676818_remove-rqth/down.sql
+++ b/hasura/migrations/carnet_de_bord/1665481676818_remove-rqth/down.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.ref_situation (description, theme) VALUES('RQTH - Rreconnaissance de la Qualité de Travailleur Handicapé', 'emploi');

--- a/hasura/migrations/carnet_de_bord/1665481676818_remove-rqth/up.sql
+++ b/hasura/migrations/carnet_de_bord/1665481676818_remove-rqth/up.sql
@@ -1,0 +1,12 @@
+
+-- move rqth data to notebook
+UPDATE notebook set right_rqth = True where id in (
+	select notebook_id
+	from notebook_focus
+	WHERE situations ? 'RQTH - Rreconnaissance de la Qualité de Travailleur Handicapé'
+);
+
+-- Remove Rqth from ref_situation
+DELETE FROM public.ref_situation WHERE description='RQTH - Rreconnaissance de la Qualité de Travailleur Handicapé';
+-- Remove Rqth from existing focus
+UPDATE notebook_focus set situations = situations - 'RQTH - Rreconnaissance de la Qualité de Travailleur Handicapé'  WHERE situations ? 'RQTH - Rreconnaissance de la Qualité de Travailleur Handicapé';


### PR DESCRIPTION
## :wrench: Problème

la situation RQTH de l'axe de travail `Emploi` est en doublons avec la situation socio-professionnelle

## :cake: Solution

on supprime RQTH des situations de l'axe "Emploi" et on le supprime des situations existantes

## :rotating_light:  Points d'attention / Remarques

Est ce que pour les carnets avec une situation RQTH on doit aussi ajouter RQTH dans la situations socio pro ?  

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1163.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #1156

Cela peut aussi être fait dans un message de commit
-->
