### PR TITLE
fix: Mettre à jour les indicateurs de l'accueil après une action / un import.

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -23881,7 +23881,7 @@ export const GetDeploymentInfosDocument = {
 									fields: [
 										{
 											kind: 'ObjectField',
-											name: { kind: 'Name', value: '_and' },
+											name: { kind: 'Name', value: '_or' },
 											value: {
 												kind: 'ListValue',
 												values: [

--- a/app/src/routes/manager/_getDeploymentInfo.gql
+++ b/app/src/routes/manager/_getDeploymentInfo.gql
@@ -9,7 +9,7 @@ query GetDeploymentInfos($id: uuid!) {
 	}
 	beneficiariesWithNoStructure: beneficiary_aggregate(
 		where: {
-			_and: [
+			_or: [
 				{ _not: { structures: {} } }
 				{ notebook: { members: { _not: { active: { _eq: true } } } } }
 			]

--- a/app/src/routes/manager/index.svelte
+++ b/app/src/routes/manager/index.svelte
@@ -15,7 +15,7 @@
 	const result = operationStore(
 		GetDeploymentInfosDocument,
 		{ id: deploymentId },
-		{ additionalTypenames: ['structure', 'professional', 'beneficiary'] }
+		{ additionalTypenames: ['structure', 'professional', 'beneficiary', 'notebook_member'] }
 	);
 	query(result);
 

--- a/app/src/routes/manager/index.svelte
+++ b/app/src/routes/manager/index.svelte
@@ -33,6 +33,10 @@
 		const success = flip ? quantity === 0 : quantity !== 0;
 		return success ? '!text-success' : '!text-marianne-red';
 	}
+
+	function refreshMetrics() {
+		return result.reexecute({ requestPolicy: 'network-only' });
+	}
 </script>
 
 <LoaderIndicator {result}>
@@ -102,6 +106,7 @@
 				title="Importer des structures"
 				size={'large'}
 				showButtons={false}
+				on:close={refreshMetrics}
 			>
 				<ImportStructures />
 			</Dialog>
@@ -113,6 +118,7 @@
 				title="Importer des bénéficiaires"
 				size={'large'}
 				showButtons={false}
+				on:close={refreshMetrics}
 			>
 				<ImportBeneficiaries />
 			</Dialog>
@@ -123,6 +129,7 @@
 				title="Procéder à des réorientations"
 				size={'large'}
 				showButtons={false}
+				on:close={refreshMetrics}
 			>
 				<svelte:fragment slot="buttonLabel">
 					<span class="block w-44"> Importer une liste<br />de réorientations</span>
@@ -136,6 +143,7 @@
 				title="Importer des chargés d'orientation"
 				size={'large'}
 				showButtons={false}
+				on:close={refreshMetrics}
 			>
 				<svelte:fragment slot="buttonLabel">
 					<span class="block w-44">Importer une liste de chargés d'orientation</span>

--- a/app/src/routes/manager/index.svelte
+++ b/app/src/routes/manager/index.svelte
@@ -12,7 +12,11 @@
 	import UpdateNotebookMembers from '$lib/ui/Manager/UpdateNotebookMembers.svelte';
 	import ImportOrientationManager from '$lib/ui/Manager/ImportOrientationManager.svelte';
 	const deploymentId = $session.user.deploymentId;
-	const result = operationStore(GetDeploymentInfosDocument, { id: deploymentId });
+	const result = operationStore(
+		GetDeploymentInfosDocument,
+		{ id: deploymentId },
+		{ additionalTypenames: ['structure', 'professional', 'beneficiary'] }
+	);
 	query(result);
 
 	$: deploymentInfo = $result.data;

--- a/app/src/routes/structures/[uuid]/index.svelte
+++ b/app/src/routes/structures/[uuid]/index.svelte
@@ -15,7 +15,7 @@
 		const getStructure = operationStore(
 			GetStructureDocument,
 			{ structureId },
-			{ additionalTypenames: ['professional'] }
+			{ additionalTypenames: ['professional', 'beneficiary_structure', 'notebook_member'] }
 		);
 
 		return {

--- a/e2e/features/manager/home.feature
+++ b/e2e/features/manager/home.feature
@@ -1,0 +1,21 @@
+#language: fr
+
+Fonctionnalité: Rattachement à une structure
+	Pour pouvoir gérer les réorientations
+	En tant que manager d'un déploiement
+	Je veux pouvoir assigner une nouvelle structure à un bénéficiaire
+
+	Scénario: Modifier la structure de rattachement d'un bénéficiaire
+		Soit un "administrateur pdi" authentifié avec l'email "support.carnet-de-bord+cd93@fabrique.social.gouv.fr"
+		Alors je vois "6"
+		Quand je clique sur "Bénéficiaires"
+		Quand j'attends que le titre de page "Bénéficiaires" apparaisse
+		Alors je vois "Centre Communal d'action social Livry-Gargan" sur la ligne "Aguilar"
+		Quand je clique sur "Non rattaché"
+		Alors je vois "Rattacher des bénéficiaires"
+		Alors j'attends que le texte "Veuillez sélectionner la structure d'accueil" apparaisse
+		Alors je selectionne l'option "AFPA" dans la liste "Nom de la structure"
+		Quand je clique sur "Rattacher"
+		Alors je vois "AFPA" sur la ligne "Aguilar"
+		Quand je clique sur "Accueil"
+		Alors je vois "5"

--- a/e2e/features/manager/rattachement.feature
+++ b/e2e/features/manager/rattachement.feature
@@ -1,7 +1,7 @@
 #language: fr
 
 Fonctionnalité: Rattachement pro
-	Pour pouvoir gérer les réorientation
+	Pour pouvoir gérer les réorientations
 	En tant que manager d'un déploiement
 	Je veux pouvoir assigner de nouveaux référents aux bénéficiaires
 


### PR DESCRIPTION
closes #1073

## :wrench: Problème

Lorsqu'un gestionnaire de structure rattache un bénéficiaire à un professionnel, les indicateurs de l'accueil ne sont pas mis à jour tant que la page n'est pas rafraichie.
Lorsqu'un manager importe des bénéficiaires, les indicateurs de l'accueil ne sont pas mis à jour tant que la page n'est pas rafraichie.

## :cake: Solution

On ajoute les `additionalTypenames` à la requête `GetStructure` pour forcer un rechargement du cache lorsque des données de type  `beneficiary_structure` et `notebook_member` sont mises à jour.
Plus d'informations dans la [documentation de `urql`](https://formidable.com/open-source/urql/docs/basics/document-caching/).

On fait la même chose pour la requête `GetDeploymentInfos` afin que les indicateurs du manager soient mis à jour après l'import de bénéficiaires.

Pour l'ensemble des imports, on force une ré-exécution de la requête des indicateurs lorsque l'import est terminé.

## :rotating_light:  Points d'attention / Remarques

En regardant la requête `GetDeploymentInfos`, j'ai l'impression que le calcul du nombre de bénéficiaires non rattachés à une structure est faux.
J'ai essayé de le corriger avec [ce commit](https://github.com/SocialGouv/carnet-de-bord/pull/1175/commits/4e5bb4b92edf3f1c170b365bde7432be4108e93d).

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1175.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->

### Gestionnaire de structures

Se connecter en tant que `jacques.celaire@livry-gargan.fr`.
Sélectionner la structure `Centre Communal d'action social Libry-Gargan`
Sélectionner la carte des bénéficiaires non attachés.
Rattacher un référent unique à un des bénéficiares de la liste.
Retourner sur l'accueil de la structure en sélectionnant `Centre Communal d'action social Libry-Gargan` dans le chemin de fer.
Constater que le nombre de bénéficiaires accompagnés a augmenté de 1.
Constater que le nombre de bénéficiaires non rattachés a diminué de 1.

### Manager

Se connecter en tant que `manager.cd93`.
Importer des bénéficiaires via un fichier CSV.
Constater que le nombre de bénéficiaires total a augmenté du nombre de bénéficiaires importés.

Se connecter en tant que manager.cd93.
Changer la structure de rattachement d'un bénéficiaire pour l'attacher à une structure sans bénéficiaire (AFPA par exemple).
Constater que le nombre de structures sans bénéficiaires total a diminué.

## 🛎️ Résultat

### Gestionnaire de structures
![ezgif com-gif-maker](https://user-images.githubusercontent.com/2989532/195706294-545d7f82-7a39-42b9-98e6-60e04590bb4d.gif)

## Manager

<p float="left">
  <img src="https://user-images.githubusercontent.com/2989532/195896923-65acae7a-6d5b-43ed-83f6-72935e43878d.gif" width="49%" />
<img src="https://user-images.githubusercontent.com/2989532/195896938-fc79ac3d-2c3f-4e07-a100-267001ae8139.gif" width="49%" /> 
</p>

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
