### PR TITLE
fix(data): recupération correcte du dernier fichier PE

### DIFF
--- a/backend/scripts/pe-fetch.sh
+++ b/backend/scripts/pe-fetch.sh
@@ -23,7 +23,7 @@ sftp -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE/$MAIN_FILE .
 
 # sftp -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE/actions .
 
-openssl smime -decrypt -in principal -binary -inform DEM -inkey pe_file.pem -out principal.csv
+openssl smime -decrypt -in $MAIN_FILE -binary -inform DEM -inkey pe_file.pem -out principal.csv
 # openssl smime -decrypt -in actions -binary -inform DEM -inkey pe_file.pem -out actions.csv
 
 echo "fichier principal: $(wc -l principal.csv) lignes"

--- a/backend/scripts/pe-fetch.sh
+++ b/backend/scripts/pe-fetch.sh
@@ -15,7 +15,7 @@ chmod 600 *.pem
 echo "download files."
 # -1rt = one column, reverse order, time sort
 # tail -1 is used in case there are multiple files with the same name (I know, it's weird but it happened)
-$MAIN_FILE=$(echo "ls -1rt" | sftp -o "StrictHostKeyChecking accept-new"  -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE | grep principal | tail -1)
+MAIN_FILE=$(echo "ls -1rt" | sftp -o "StrictHostKeyChecking accept-new"  -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE | grep principal | tail -1)
 sftp -i ./pe_server.pem $PE_SERVER_URL:/OI33SPIE/$MAIN_FILE .
 
 # Processing of the "actions" file is disabled for now because it is too large to be decrypted


### PR DESCRIPTION
## :wrench: Problème

le script `pe-fetch` récupère la dernière version du fichier. pour cela on exécute une commande et on place le résultat dans une variable. Le nom de la variable était préfixé inutilement d'un `$`. 

## :cake: Solution

suppression du caractère en trop.

 

## :desert_island: Comment tester

Il va falloir lancer le script manuellement et valider qu'il prend bien en compte le dernier fichier
fix #1162 

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1176.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->