### PR TITLE
chore: Ajout d'un precommit hook pour assurer la fraîcheur de la génération `codegen`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,12 @@ repos:
         language: system
         pass_filenames: false
         files: ^app/.*\.gql$
+        # To determine if codegen needs to be ran, modification and commit dates
+        # of all *.gql files and the generated file are computed, and then sorted.
+        # For this we use git log and git status commands.
+        # The most recent date is kept.
+        # Finally, the most recent date shall be the one of the generated file.
+        # Otherwise, it means that genereted file has to be re-generated.
         entry: |
           bash -c 'for i in "*.gql" app/src/lib/graphql/_gen/typed-document-nodes.ts; do echo $(git log -1 --format=%ct $i) $i; git status --porcelain "$i" |cut -c4-|xargs stat -f "%m %N"; done | sort | tail -1 | grep -F "app/src/lib/graphql/_gen/typed-document-nodes.ts"' --
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,13 @@ repos:
         entry: |
           ./scripts/check-hasura-version.sh
 
+      - id: check-codegen
+        name: check if codegen needs to be ran
+        language: system
+        pass_filenames: false
+        files: ^app/.*\.gql$
+        entry: |
+          bash -c 'for i in "*.gql" app/src/lib/graphql/_gen/typed-document-nodes.ts; do echo $(git log -1 --format=%ct $i) $i; git status --porcelain "$i" |cut -c4-|xargs stat -f "%m %N"; done | sort | tail -1 | grep -F "app/src/lib/graphql/_gen/typed-document-nodes.ts"' --
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: 'v8.0.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,10 @@ repos:
         # Finally, the most recent date shall be the one of the generated file.
         # Otherwise, it means that genereted file has to be re-generated.
         entry: |
-          bash -c 'for i in "*.gql" app/src/lib/graphql/_gen/typed-document-nodes.ts; do echo $(git log -1 --format=%ct $i) $i; git status --porcelain "$i" |cut -c4-|xargs stat -f "%m %N"; done | sort | tail -1 | grep -F "app/src/lib/graphql/_gen/typed-document-nodes.ts"' --
+          bash -c 'for i in "*.gql" app/src/lib/graphql/_gen/typed-document-nodes.ts;
+            do echo $(git log -1 --format=%ct $i) $i;
+            git status --porcelain "$i" |cut -c4-|xargs stat -f "%m %N";
+          done | sort | tail -1 | grep -F "app/src/lib/graphql/_gen/typed-document-nodes.ts"' --
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: 'v8.0.0'


### PR DESCRIPTION
## :wrench: Problème

Le fichier de types `app/src/lib/graphql/_gen/typed-document-nodes.ts` est généré en utilisant la commande `yarn —cwd app codegen`.

Actuellement le fichier est versionné avec le code dans le git.

Cela pose parfois des soucis car un changement dans les queries ou mutations (par exemple en changeant un fichier `.gql`) n’entraine pas une re-génération du fichier de types.

## :cake: Solution

Afin de garantir que le fichier généré est à jour, on ajoute un hook de precommit qui échoue si le fichier de sortie `typed-document-nodes` est plus ancien que l'ensemble des fichiers `*.gql`.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

Modifier un fichier `*.gql`.
Essayer de le commiter **sans générer** les types auparavant.
Vérifier que le hook de precommit `check-codegen` échoue.

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1177.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->



<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
