### PR TITLE
chore: Utiliser `npm` pour créer les versions.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,7 @@ plugins:
   - - "@semantic-release/exec"
     - execCwd: "app"
       prepareCmd: |
-        yarn version --new-version ${nextRelease.version} --no-git-tag-version
+        npm version ${nextRelease.version} --no-git-tag-version
 # bump backend version (pyproject.toml)
   - - "@semantic-release/exec"
     - execCwd: "backend"
@@ -16,6 +16,7 @@ plugins:
     - assets:
         - CHANGELOG.md
         - app/package.json
+        - app/package-lock.json
         - backend/pyproject.toml
       message: "chore(release): ${nextRelease.version}"
   - "@semantic-release/github"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,9 +33,7 @@ cp .env.sample .env
 **3/** Récupérer les dépendances du projet
 
 ```sh
-cd app
-yarn # installer les dépendances de l'application
-cd -
+npm ci --prefix app # installer les dépendances de l'application
 pre-commit install # installer les hooks Git
 ```
 
@@ -68,8 +66,7 @@ hasura console --envfile ../.env # lancer la console hasura en utilisant les var
 Dans un troisième terminal :
 
 ```sh
-cd app
-yarn dev # démarrer le serveur de développement SvelteKit
+npm --prefix app run dev # démarrer le serveur de développement SvelteKit
 ```
 
 **7/** Configurer et démarrer l'API back-end métier


### PR DESCRIPTION
## :wrench: Problème

On a migré le gestionnaire de dépendence de l'application `svelte` de `yarn` vers `npm`.
Dans cette migration on a oublié de mettre à jour la création des releases.

## :cake: Solution

Adapter la commande de création de la release (dans le fichier `.releaserc`).
Ajouter le fichier `package-lock.json` dans les fichiers à commiter lors de la création d'une release car ce fichier contient le numéron de version de l'application.


## :rotating_light:  Points d'attention / Remarques

Au passage, on en profite pour mettre à jour les dernières mentions de l'usage de `yarn` dans la documentation.

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->

Se rendre sur la [review app](https://cdb-app-review-pr1205.osc-fr1.scalingo.io).

<!-- END ## emplacement de l'URL de la review app ## -->


<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
