### PR TITLE
fix: Certains utilisateurs reçoivent un lien de connexion invalide.

### DIFF
--- a/app/src/lib/graphql/_gen/typed-document-nodes.ts
+++ b/app/src/lib/graphql/_gen/typed-document-nodes.ts
@@ -2660,9 +2660,9 @@ export type DeploymentOrientationSystem = {
 	deployment: Deployment;
 	deploymentId: Scalars['uuid'];
 	id: Scalars['uuid'];
-	orientationSystemId: Scalars['uuid'];
 	/** An object relationship */
-	orientation_system: OrientationSystem;
+	orientationSystem: OrientationSystem;
+	orientationSystemId: Scalars['uuid'];
 };
 
 /** aggregated selection of "deployment_orientation_system" */
@@ -2720,8 +2720,8 @@ export type DeploymentOrientationSystemBoolExp = {
 	deployment?: InputMaybe<DeploymentBoolExp>;
 	deploymentId?: InputMaybe<UuidComparisonExp>;
 	id?: InputMaybe<UuidComparisonExp>;
+	orientationSystem?: InputMaybe<OrientationSystemBoolExp>;
 	orientationSystemId?: InputMaybe<UuidComparisonExp>;
-	orientation_system?: InputMaybe<OrientationSystemBoolExp>;
 };
 
 /** unique or primary key constraints on table "deployment_orientation_system" */
@@ -2736,8 +2736,8 @@ export type DeploymentOrientationSystemInsertInput = {
 	deployment?: InputMaybe<DeploymentObjRelInsertInput>;
 	deploymentId?: InputMaybe<Scalars['uuid']>;
 	id?: InputMaybe<Scalars['uuid']>;
+	orientationSystem?: InputMaybe<OrientationSystemObjRelInsertInput>;
 	orientationSystemId?: InputMaybe<Scalars['uuid']>;
-	orientation_system?: InputMaybe<OrientationSystemObjRelInsertInput>;
 };
 
 /** aggregate max on columns */
@@ -2796,8 +2796,8 @@ export type DeploymentOrientationSystemOrderBy = {
 	deployment?: InputMaybe<DeploymentOrderBy>;
 	deploymentId?: InputMaybe<OrderBy>;
 	id?: InputMaybe<OrderBy>;
+	orientationSystem?: InputMaybe<OrientationSystemOrderBy>;
 	orientationSystemId?: InputMaybe<OrderBy>;
-	orientation_system?: InputMaybe<OrientationSystemOrderBy>;
 };
 
 /** primary key columns input for table: deployment_orientation_system */
@@ -16720,7 +16720,6 @@ export type GetAccountInfoQuery = {
 
 export type ResetAccountAccessKeyMutationVariables = Exact<{
 	id: Scalars['uuid'];
-	now: Scalars['timestamptz'];
 }>;
 
 export type ResetAccountAccessKeyMutation = {
@@ -28784,14 +28783,6 @@ export const ResetAccountAccessKeyDocument = {
 						type: { kind: 'NamedType', name: { kind: 'Name', value: 'uuid' } },
 					},
 				},
-				{
-					kind: 'VariableDefinition',
-					variable: { kind: 'Variable', name: { kind: 'Name', value: 'now' } },
-					type: {
-						kind: 'NonNullType',
-						type: { kind: 'NamedType', name: { kind: 'Name', value: 'timestamptz' } },
-					},
-				},
 			],
 			selectionSet: {
 				kind: 'SelectionSet',
@@ -28833,7 +28824,7 @@ export const ResetAccountAccessKeyDocument = {
 										{
 											kind: 'ObjectField',
 											name: { kind: 'Name', value: 'lastLogin' },
-											value: { kind: 'Variable', name: { kind: 'Name', value: 'now' } },
+											value: { kind: 'EnumValue', value: 'now' },
 										},
 									],
 								},

--- a/app/src/routes/auth/jwt/[uuid]/+page.svelte
+++ b/app/src/routes/auth/jwt/[uuid]/+page.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { Button, Spinner } from '$lib/ui/base';
 
 	import type { PageServerData } from './$types';
 	export let data: PageServerData;
 
-	onMount(() => {
+	$: isLoading = false;
+
+	async function login() {
+		const body = new FormData();
+		body.set('token', data.token);
+		body.set('accountId', data.accountId);
+		await fetch(`/auth/jwt/${data.accessKey}`, { method: 'POST', body });
+
 		window.location.replace(data.redirectAfterLogin ?? '/');
-	});
+	}
 </script>
 
 <div class="pt-28 flex flex-col grow items-center">
-	<p class="pb-12 text-xl">Chargement en cours…</p>
+	<p class="pb-12 text-xl">Votre lien magique est valide.</p>
+	{#if isLoading}
+		<Spinner />
+	{:else}
+		<Button on:click={login} title="Continuer">Continuer sur Carnet de bord</Button>
+	{/if}
 </div>

--- a/app/src/routes/auth/jwt/_updateAccount.gql
+++ b/app/src/routes/auth/jwt/_updateAccount.gql
@@ -1,7 +1,7 @@
-mutation ResetAccountAccessKey($id: uuid!, $now: timestamptz!) {
+mutation ResetAccountAccessKey($id: uuid!) {
   update_account_by_pk(
     pk_columns: { id: $id }
-    _set: { accessKeyDate: null, accessKey: null, lastLogin: $now }
+    _set: { accessKeyDate: null, accessKey: null, lastLogin: now }
   ) {
     lastLogin
   }

--- a/e2e/step_definitions/steps.js
+++ b/e2e/step_definitions/steps.js
@@ -30,7 +30,8 @@ function plainGoto(url) {
 Soit("un {string} authentifié avec l'email {string}", async (userType, email) => {
 	await onBoardingSetup(userType, email, true);
 	const uuid = await loginStub(userType, email);
-	plainGoto(`/auth/jwt/${uuid}`);
+	await plainGoto(`/auth/jwt/${uuid}`);
+	I.click('Continuer sur Carnet de bord');
 });
 
 Soit(
@@ -38,7 +39,8 @@ Soit(
 	async (userType, email) => {
 		await onBoardingSetup(userType, email, false);
 		const uuid = await loginStub(userType, email);
-		plainGoto(`/auth/jwt/${uuid}`);
+		await plainGoto(`/auth/jwt/${uuid}`);
+		I.click('Continuer sur Carnet de bord');
 	}
 );
 
@@ -52,13 +54,15 @@ Quand('je vais sur la page {string}', (page) => {
 
 Soit('le pro {string} qui a cliqué sur le lien de connexion', async (email) => {
 	const uuid = await loginStub('pro', email);
-	plainGoto(`/auth/jwt/${uuid}`);
+	await plainGoto(`/auth/jwt/${uuid}`);
+	I.click('Continuer sur Carnet de bord');
 });
 
 Soit('le pro {string} sur le carnet de {string}', async (email, lastname) => {
 	const uuid = await loginStub('pro', email);
 	const notebookId = await goToNotebookForLastName(lastname);
-	plainGoto(`/auth/jwt/${uuid}?url=/pro/carnet/${notebookId}`);
+	await plainGoto(`/auth/jwt/${uuid}?url=/pro/carnet/${notebookId}`);
+	I.click('Continuer sur Carnet de bord');
 });
 
 Soit(
@@ -68,7 +72,8 @@ Soit(
 		const uuid = await loginStub("chargé d'orientation", email);
 		const notebookId = await goToNotebookForLastName(lastname);
 		await addMember(email, notebookId);
-		plainGoto(`/auth/jwt/${uuid}?url=/orientation/carnets/edition/${notebookId}`);
+		await plainGoto(`/auth/jwt/${uuid}?url=/orientation/carnets/edition/${notebookId}`);
+		I.click('Continuer sur Carnet de bord');
 	}
 );
 
@@ -76,7 +81,8 @@ Soit("le chargé d'orientation {string} sur le carnet de {string}", async (email
 	await onBoardingSetup("chargé d'orientation", email, true);
 	const uuid = await loginStub("chargé d'orientation", email);
 	const notebookId = await goToNotebookForLastName(lastname);
-	plainGoto(`/auth/jwt/${uuid}?url=/orientation/carnets/${notebookId}`);
+	await plainGoto(`/auth/jwt/${uuid}?url=/orientation/carnets/${notebookId}`);
+	I.click('Continuer sur Carnet de bord');
 });
 
 //


### PR DESCRIPTION
## :wrench: Problème

Certains utilisateurs, depuis le courriel contenant le lien magique, se voient redirigés vers la page d'erreur `Désolé, ce lien n'est plus valide`.
Comme le lien est à usage unique, il est probable (bien que pas encore confirmé) que certains clients mails tentent d'afficher une preview (malgré le `nofollow` dans l'url) ce qui réinitialise l'acces key associé au lien.

## :cake: Solution

En l'absence de certitude, on ajoute une étape après le lien magique.
L'utilisateur doit désormais cliquer sur un bouton `Continuer sur Carnet de bord`.
Techniquement on passe par une action SvelteKit (ce qui est en fait un `POST`) après un clic sur le bouton `Continuer sur Carnet de bord`.


## :rotating_light:  Points d'attention / Remarques

RAS

## :desert_island: Comment tester

<!-- BEGIN ## emplacement de l'URL de la review app ## -->
Ne pas supprimer ce bloc, qui sera mis à jour [automatiquement](.github/workflows/review-scalingo.yml).
<!-- END ## emplacement de l'URL de la review app ## -->
Se connecter avec n'importe quel compte de démo.
Cliquer ensuite sur le bouton `Continuer sur Carnet de bord`.
Vérifier que l'on est bien redirigé sur la page d'accueil de l'utilisateur.

fixes #1443

<!--
Pour lier votre PR à une issue et que cette dernière soit fermée lorsque la PR sera fusionnée dans master, vous pouvez utiliser l'annotation `fix` en précisant le numéro de la PR précédé de `#`
ex: fix #42

Cela peut aussi être fait dans un message de commit
-->
