### PR TITLE
fix: Améliorer l'affichage de la popup de rattachement

### DIFF
--- a/app/src/lib/ui/Beneficiary/NotebookMembers.svelte
+++ b/app/src/lib/ui/Beneficiary/NotebookMembers.svelte
@@ -133,7 +133,7 @@
 						ariaControls="orientation-system"
 					/>
 					{#if orientationOptions.length && form.memberType === 'referent'}
-						<div class="fr-form-group pb-3">
+						<div class="fr-form-group pb-6">
 							<Select
 								options={orientationOptions}
 								name="orientation"

--- a/e2e/features/pro/carnet/read_only_other_notebook.feature
+++ b/e2e/features/pro/carnet/read_only_other_notebook.feature
@@ -19,7 +19,7 @@ Fonctionnalité: Accès en lecture seule à un carnet dont je ne suis pas membre
 		Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Henderson"
 		Alors j'attends que le texte "Myrna Henderson" apparaisse
 		Alors je clique sur "Se rattacher"
-		Alors je vois "Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
+		Alors je vois "Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
 		Alors je clique sur "Non"
 		Alors je clique sur "Se rattacher" dans la modale
 		Alors je vois "Pierre Chevalier" sous le titre "Groupe de suivi"
@@ -32,7 +32,7 @@ Fonctionnalité: Accès en lecture seule à un carnet dont je ne suis pas membre
 		Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Henderson"
 		Alors j'attends que le texte "Myrna Henderson" apparaisse
 		Alors je clique sur "Se rattacher"
-		Alors je vois "Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
+		Alors je vois "Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
 		Alors je clique sur "Oui"
 		Quand je sélectionne l'option "Professionnel" dans la liste "Dispositif d’accompagnement"
 		Alors je clique sur "Se rattacher" dans la modale

--- a/e2e/features/pro/carnet/sociopro.feature
+++ b/e2e/features/pro/carnet/sociopro.feature
@@ -60,7 +60,7 @@ Fonctionnalité: Informations sur le bénéficaire
 		Soit le pro "pierre.chevalier@livry-gargan.fr" sur le carnet de "Dorsey"
 		Alors j'attends que le texte "Hendrix Dorsey" apparaisse
 		Alors je clique sur "Se rattacher"
-		Alors je vois "Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
+		Alors je vois "Bénéficiez-vous d'un mandat d'orientation en la qualité de référent ?"
 		Alors je clique sur "Oui"
 		Alors je sélectionne l'option "Professionnel" dans la liste "Dispositif d’accompagnement"
 		Alors je clique sur "Se rattacher" dans la modale


### PR DESCRIPTION
## :wrench: Problème

Lorsqu'on sélectionne "oui" (rattacher en tant que référent?) le champs Dispositif d'accompagnement est collé au bouton Se rattacher. De plus le point d'interrogation est renvoyé à la ligne.

Fix #1798 

## :cake: Solution

On ajoute un padding bottom au bouton et on met un espace insécable avant le `?`


## :desert_island: Comment tester

Vérifier que le bouton `Se rattacher` n'est plus collé lorsque l'on bénéficie d'un mandat d'orientation.
